### PR TITLE
chore: align @types/node to Node 20

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,10 @@
-
+# .github/dependabot.yml
 version: 2
 updates:
-  # Enable version updates for npm
-  - package-ecosystem: "npm"
-    # Look for `package.json` and `lock` files in the `root` directory
-    directory: "/"
-    # Check the npm registry for updates every day (weekdays)
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "daily"
+      interval: monthly
+    ignore:
+      - dependency-name: '@types/node'
+        update-types: ['version-update:semver-major']


### PR DESCRIPTION
Avoid types/runtime drift; prod is Node 20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Adjusted automated dependency updates to run monthly instead of daily, reducing update noise while keeping dependencies current.
  - Set rules to skip major updates for a development typing package to avoid disruptive changes in tooling.
  - Performed minor configuration cleanups for consistency.
  - No user-facing changes or product behavior impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->