### PR TITLE
changeset added: Raise minimum Node to 22.12.0 to fix Sanity typegen (ESM/CJS interop).

### DIFF
--- a/.changeset/better-deer-fold.md
+++ b/.changeset/better-deer-fold.md
@@ -1,0 +1,9 @@
+---
+"studio": patch
+"web": patch
+"@workspace/eslint-config": patch
+"@workspace/typescript-config": patch
+"@workspace/ui": patch
+---
+
+Raise minimum Node to 22.12.0 to fix Sanity typegen (ESM/CJS interop).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Prepared patch releases across Studio, Web, UI, ESLint config, and TypeScript config packages.
  - Raised the minimum required Node.js version to 22.12.0.

- Notes for Users
  - Update your environment to Node.js 22.12.0 or later to install and run the latest packages.
  - These updates are patch-level with no changes to public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->