### PR TITLE
Feat/sauces-index-list

### DIFF
--- a/.changeset/add-sauces-index-and-stub.md
+++ b/.changeset/add-sauces-index-and-stub.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Add Sauces Index page with SSR + client filtering (search via Fuse.js, product line multi-select, sauce type single-select), A→Z/Z→A sorting, URL param syncing, responsive sidebar/sheet filters, and accessibility improvements. Also scaffold a basic sauce detail route at `/sauces/[slug]` as a stub for future work.

--- a/.changeset/add-sauces-index-and-stub.md
+++ b/.changeset/add-sauces-index-and-stub.md
@@ -1,5 +1,5 @@
 ---
-"web": patch
+"web": minor
 ---
 
-Add Sauces Index page with SSR + client filtering (search via Fuse.js, product line multi-select, sauce type single-select), A→Z/Z→A sorting, URL param syncing, responsive sidebar/sheet filters, and accessibility improvements. Also scaffold a basic sauce detail route at `/sauces/[slug]` as a stub for future work.
+Add Sauces Index page with SSR + client filtering (search via Fuse.js, product line multi-select, sauce type single-select), A→Z/Z→A sorting, URL param syncing, responsive sidebar/sheet filters, and accessibility improvements. Also scaffold a basic sauce detail route at `/sauces/[slug]`.

--- a/.changeset/harden-badge-typing.md
+++ b/.changeset/harden-badge-typing.md
@@ -1,0 +1,9 @@
+---
+"@workspace/ui": patch
+---
+
+Harden Badge typing and remove `any` cast
+
+- Use a discriminated union for anchor vs. span props
+- Conditionally pass `href` only when rendering an `<a>`
+- Keep `text`, `className`, and `variant` API unchanged

--- a/.changeset/introduce-eyebrow-and-refactor-badges.md
+++ b/.changeset/introduce-eyebrow-and-refactor-badges.md
@@ -1,0 +1,12 @@
+---
+"web": minor
+"@workspace/ui": minor
+---
+
+Introduce Eyebrow component and refactor badge usage across sections
+
+- Add `Eyebrow` UI component (`@workspace/ui/components/eyebrow`) with CVA variants `onLight` (default) and `onDark`. No background fill; uses a 1px left border and 1rem left padding; small text. Skips rendering when text is empty. Supports optional `aria-label` for accessibility.
+- Refactor web sections to use `Eyebrow` instead of `Badge`:
+  - `hero.tsx`, `cta.tsx`, `faq-accordion.tsx`, `image-link-cards.tsx`, `feature-cards-with-icon.tsx`.
+- Keep `Badge` only for sauce cards; move color logic into `Badge` CVA variants (`original`, `organic`, `premium`, `pizza`, `pasta`, `salsa`, `sandwich`).
+- Simplify `Badge` API (required `text`, optional `href`) so the component only handles styling while callers supply content/links.

--- a/.changeset/web-badge-variant-refactor.md
+++ b/.changeset/web-badge-variant-refactor.md
@@ -1,0 +1,9 @@
+---
+"web": patch
+---
+
+Use `Badge` variant prop in SauceCard and sauce taxonomy for consistency and accessibility
+
+- Switch SauceCard to variant-based `Badge` usage
+- Align `src/config/sauce-taxonomy.ts` with `Badge` variants
+- No intended UI or behavior changes

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ npm-debug.log*
 # Sanity
 .sanity
 /apps/studio/exports
+/apps/studio/backups
 
 # playwright
 .playwright-mcp

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ AI agent handbook for exploring, editing, and shipping safely in this monorepo
 - Prefer semantic code search; use exact grep when you know the symbol. Parallelize independent searches.
 - Fetch external docs when needed (don’t rely on assumptions). Prefer most up-to-date sources.
 - Do not commit or push unless explicitly asked. Use GitHub CLI only when requested.
-- After any code changes, run `pnpm -C <affected> lint:fix` and typecheck before handing off.
+- Iteration default: do not run builds unless explicitly requested. After any code changes, run Prettier on the changed workspace(s) and then lint+typecheck: `pnpm -C <affected> format && pnpm -C <affected> lint:fix && pnpm -C <affected> typecheck`.
 
 ### Coding standards
 
@@ -111,7 +111,8 @@ Sanity Types (tight coupling)
 
 ### Quality gates
 
-- For web changes: `pnpm -C apps/web lint:fix && pnpm -C apps/web typecheck && pnpm -C apps/web build`.
+- Iteration (agents): `pnpm -C apps/web format && pnpm -C apps/web lint:fix && pnpm -C apps/web typecheck` (skip build unless asked).
+- Pre-PR validation: `pnpm -C apps/web lint:fix && pnpm -C apps/web typecheck && pnpm -C apps/web build`.
 - For studio changes: `pnpm -C apps/studio lint:fix && pnpm -C apps/studio check`.
 - Root checks (multi-package updates): `pnpm lint && pnpm check-types && pnpm build`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,31 @@ AI agent handbook for exploring, editing, and shipping safely in this monorepo
 ### Sanity studio (apps/studio)
 
 - Schemas under `studio/schemaTypes/**`. Always use `defineType` and `defineField`.
-- After schema changes: `pnpm -C apps/studio run type` to extract and generate types.
+- After schema changes or updating/adding queries in `apps/web/src/lib/sanity/query.ts`: always run typegen to keep types in sync.
+  - Studio: `pnpm -C apps/studio run type` (extract + generate)
+  - Then re-run web typecheck/build.
+  - Keep web tightly coupled to generated types; derive UI types from generated query results where feasible.
+
+### Live Preview & Presentation
+
+// IMPORTANT: We use next-sanity v10 Live Content API — do NOT use the older preview APIs.
+
+- Do NOT import or use legacy preview components from `next-sanity/preview` or `@sanity/preview-kit` (e.g. `LiveQuery`, `useLiveQuery`, `LiveQueryProvider`). They are deprecated for our setup.
+- DO use `defineLive` from `next-sanity` to export `sanityFetch` and `SanityLive` (already configured in `apps/web/src/lib/sanity/live.ts`).
+  - Mount `<SanityLive />` at the end of the root layout body (already done).
+  - Fetch page data with `sanityFetch` in server components. This auto-switches to the Live Content API when Draft Mode is enabled.
+- Keep Presentation metadata intact: never force `stega: false` for fetches that render visible content. This is required for:
+  - Live updates while editing drafts (in Presentation)
+  - Showing "Documents on this page"
+  - Click-to-edit overlay/inspector
+- Optional debug only: if needed, use hooks from `next-sanity/hooks` (e.g. `useIsLivePreview`) — avoid legacy preview providers.
+
+Sanity Types (tight coupling)
+
+- After schema or query edits (in `apps/web/src/lib/sanity/query.ts`), always run Studio typegen:
+  - `pnpm -C apps/studio type`
+  - Then re-run web typecheck/build
+- Derive web UI types from generated query results in `apps/web/src/lib/sanity/sanity.types.ts` (e.g., `GetXQueryResult`) rather than hand-rolling shapes.
 - Keep icons consistent (prefer `@sanity/icons`, fallback to `lucide-react`).
 - Follow GROQ rules: prefer explicit filtering and fragments; don’t expand images unless asked.
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "@workspace/ui": "workspace:*",
     "babel-plugin-react-compiler": "19.1.0-rc.2",
     "framer-motion": "^11.18.2",
+    "fuse.js": "^7.1.0",
     "lucide-react": "^0.539.0",
     "next": "^15.5.2",
     "next-sanity": "^10.0.12",

--- a/apps/web/src/app/[...slug]/page.tsx
+++ b/apps/web/src/app/[...slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import { PageBuilder } from "@/components/pagebuilder";
@@ -28,9 +29,9 @@ async function fetchSlugPagePaths() {
 export async function generateMetadata({
   params,
 }: {
-  params: Promise<{ slug: string[] }>;
-}) {
-  const { slug } = await params;
+  params: { slug: string[] };
+}): Promise<Metadata> {
+  const { slug } = params;
   const slugString = slug.join("/");
   const { data: pageData } = await fetchSlugPageData(slugString, false);
   return getSEOMetadata(
@@ -53,9 +54,9 @@ export async function generateStaticParams() {
 export default async function SlugPage({
   params,
 }: {
-  params: Promise<{ slug: string[] }>;
+  params: { slug: string[] };
 }) {
-  const { slug } = await params;
+  const { slug } = params;
   const slugString = slug.join("/");
   const { data: pageData } = await fetchSlugPageData(slugString);
 

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import { RichText } from "@/components/elements/rich-text";
@@ -30,9 +31,9 @@ async function fetchBlogPaths() {
 export async function generateMetadata({
   params,
 }: {
-  params: Promise<{ slug: string }>;
-}) {
-  const { slug } = await params;
+  params: { slug: string };
+}): Promise<Metadata> {
+  const { slug } = params;
   const { data } = await fetchBlogSlugPageData(slug, false);
   return getSEOMetadata(
     data
@@ -55,9 +56,9 @@ export async function generateStaticParams() {
 export default async function BlogSlugPage({
   params,
 }: {
-  params: Promise<{ slug: string }>;
+  params: { slug: string };
 }) {
-  const { slug } = await params;
+  const { slug } = params;
   const { data } = await fetchBlogSlugPageData(slug);
   if (!data) return notFound();
   const { title, description, image, richText } = data ?? {};

--- a/apps/web/src/app/blog/page.tsx
+++ b/apps/web/src/app/blog/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import { BlogCard, BlogHeader, FeaturedBlogCard } from "@/components/blog-card";
@@ -12,7 +13,7 @@ async function fetchBlogPosts() {
   return await handleErrors(sanityFetch({ query: queryBlogIndexPageData }));
 }
 
-export async function generateMetadata() {
+export async function generateMetadata(): Promise<Metadata> {
   const { data: result } = await sanityFetch({
     query: queryBlogIndexPageData,
     stega: false,

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,4 +1,6 @@
 // import { PageBuilder } from "@/components/pagebuilder";
+import type { Metadata } from "next";
+
 import { HomeSlideshow } from "@/components/HomeSlideshow";
 import { PageBuilder } from "@/components/pagebuilder";
 import { sanityFetch } from "@/lib/sanity/live";
@@ -11,7 +13,7 @@ async function fetchHomePageData() {
   });
 }
 
-export async function generateMetadata() {
+export async function generateMetadata(): Promise<Metadata> {
   const { data: homePageData } = await fetchHomePageData();
   return getSEOMetadata(
     homePageData

--- a/apps/web/src/app/sauces/[slug]/page.tsx
+++ b/apps/web/src/app/sauces/[slug]/page.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link";
+
+import { getSEOMetadata } from "@/lib/seo";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  return getSEOMetadata({
+    title: `Sauce: ${slug}`,
+    description: "Sauce details coming soon.",
+    slug: `/sauces/${slug}`,
+    pageType: "article",
+  });
+}
+
+export default async function SauceDetailPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  return (
+    <main className="bg-background">
+      <div className="container my-16 mx-auto px-4 md:px-6">
+        <div className="mx-auto max-w-2xl text-center">
+          <h1 className="text-3xl font-bold sm:text-4xl">{slug}</h1>
+          <p className="mt-4 text-lg leading-8 text-muted-foreground">
+            Sauce details coming soon.
+          </p>
+          <div className="mt-8">
+            <Link
+              href="/sauces"
+              className="underline underline-offset-4 hover:no-underline"
+            >
+              ← Back to all sauces
+            </Link>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/sauces/[slug]/page.tsx
+++ b/apps/web/src/app/sauces/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 
 import { getSEOMetadata } from "@/lib/seo";
@@ -5,9 +6,9 @@ import { getSEOMetadata } from "@/lib/seo";
 export async function generateMetadata({
   params,
 }: {
-  params: Promise<{ slug: string }>;
-}) {
-  const { slug } = await params;
+  params: { slug: string };
+}): Promise<Metadata> {
+  const { slug } = params;
   return getSEOMetadata({
     title: `Sauce: ${slug}`,
     description: "Sauce details coming soon.",
@@ -19,9 +20,9 @@ export async function generateMetadata({
 export default async function SauceDetailPage({
   params,
 }: {
-  params: Promise<{ slug: string }>;
+  params: { slug: string };
 }) {
-  const { slug } = await params;
+  const { slug } = params;
   return (
     <main className="bg-background">
       <div className="container my-16 mx-auto px-4 md:px-6">

--- a/apps/web/src/app/sauces/page.tsx
+++ b/apps/web/src/app/sauces/page.tsx
@@ -28,7 +28,12 @@ export async function generateMetadata(): Promise<Metadata> {
           contentId: data?._id,
           contentType: data?._type,
         }
-      : {},
+      : {
+          title: "Premium Sauces",
+          description:
+            "Discover the Heart of Authentic Italian Flavor with Our Original Pasta, Pizza and Sandwich Sauces.",
+          slug: "/sauces",
+        },
   );
 }
 
@@ -60,21 +65,26 @@ export default async function SaucesIndexPage({
   const resolvedSearchParams = (await searchParams) ?? {};
   const initialState: SauceQueryState = parseSearchParams(resolvedSearchParams);
 
+  // Fallback copy so the page always shows intro even if CMS data is missing
+  const heading = indexDoc?.title ?? "Premium Sauces";
+  const intro =
+    indexDoc?.description ??
+    "Discover the Heart of Authentic Italian Flavor with Our Original Pasta, Pizza and Sandwich Sauces.";
+
   return (
     <main>
       <div className="container py-60 mx-auto px-4 md:px-6">
-        <div className="mx-auto max-w-2xl text-center">
-          <h1 className="text-3xl font-bold sm:text-4xl">
-            {indexDoc?.title ?? "Sauces"}
+        {/* Page intro: left-aligned heading + paragraph to match comps */}
+        <div className="max-w-3xl text-start">
+          <h1 className="text-3xl font-bold sm:text-5xl text-brand-green">
+            {heading}
           </h1>
-          {indexDoc?.description ? (
-            <p className="mt-4 text-lg leading-8 text-muted-foreground">
-              {indexDoc.description}
-            </p>
-          ) : null}
+          <p className="mt-4 text-xl leading-8 text-muted-foreground">
+            {intro}
+          </p>
         </div>
 
-        <div className="mt-8">
+        <div className="mt-16">
           <SaucesClient items={items} initialState={initialState} />
         </div>
       </div>

--- a/apps/web/src/app/sauces/page.tsx
+++ b/apps/web/src/app/sauces/page.tsx
@@ -73,7 +73,7 @@ export default async function SaucesIndexPage({
 
   return (
     <main>
-      <div className="container py-60 mx-auto px-4 md:px-6">
+      <div className="container py-40 md:py-60 mx-auto px-4 md:px-6">
         {/* Page intro: left-aligned heading + paragraph to match comps */}
         <div className="max-w-3xl text-start">
           <h1 className="text-3xl font-bold sm:text-5xl text-brand-green">

--- a/apps/web/src/app/sauces/page.tsx
+++ b/apps/web/src/app/sauces/page.tsx
@@ -1,0 +1,85 @@
+import { notFound } from "next/navigation";
+
+import { SaucesClient } from "@/components/sauces/sauces-client";
+import { sanityFetch } from "@/lib/sanity/live";
+import {
+  getAllSaucesForIndexQuery,
+  getSauceIndexPageQuery,
+} from "@/lib/sanity/query";
+import { parseSearchParams, type SauceQueryState } from "@/lib/sauces/url";
+import { getSEOMetadata } from "@/lib/seo";
+import type { SauceIndexPageData, SauceListItem } from "@/types";
+import { handleErrors } from "@/utils";
+
+export async function generateMetadata() {
+  const { data: result } = await sanityFetch({
+    query: getSauceIndexPageQuery,
+    stega: false,
+  });
+
+  const data = result as SauceIndexPageData | null;
+  return getSEOMetadata(
+    data
+      ? {
+          title: data?.title ?? "",
+          description: data?.description ?? "",
+          slug: "/sauces",
+          contentId: data?._id,
+          contentType: data?._type,
+        }
+      : {},
+  );
+}
+
+async function fetchSauces() {
+  return await handleErrors(
+    sanityFetch({ query: getAllSaucesForIndexQuery, stega: false }),
+  );
+}
+
+async function fetchIndexCopy() {
+  return await handleErrors(
+    sanityFetch({ query: getSauceIndexPageQuery, stega: false }),
+  );
+}
+
+export default async function SaucesIndexPage({
+  searchParams,
+}: {
+  searchParams?: Record<string, string | string[] | undefined>;
+}) {
+  const [saucesRes, copyRes] = await Promise.all([
+    fetchSauces(),
+    fetchIndexCopy(),
+  ]);
+  const [saucesData, saucesErr] = saucesRes;
+  const [copyData] = copyRes;
+  if (saucesErr) notFound();
+
+  const indexDoc = (copyData?.data ?? null) as SauceIndexPageData | null;
+  const items = (saucesData?.data ?? []) as SauceListItem[];
+
+  const initialState: SauceQueryState = parseSearchParams(searchParams ?? {});
+
+  return (
+    <main className="bg-background">
+      <div className="container my-16 mx-auto px-4 md:px-6">
+        <div className="mx-auto max-w-2xl text-center">
+          <h1 className="text-3xl font-bold sm:text-4xl">
+            {indexDoc?.title ?? "Sauces"}
+          </h1>
+          {indexDoc?.description ? (
+            <p className="mt-4 text-lg leading-8 text-muted-foreground">
+              {indexDoc.description}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="mt-8">
+          {/* Client manages state; SSR computes same initial results to avoid flash */}
+          <SaucesClient items={items} initialState={initialState} />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/sauces/page.tsx
+++ b/apps/web/src/app/sauces/page.tsx
@@ -10,11 +10,11 @@ import { parseSearchParams, type SauceQueryState } from "@/lib/sauces/url";
 import { getSEOMetadata } from "@/lib/seo";
 import type { SauceIndexPageData, SauceListItem } from "@/types";
 import { handleErrors } from "@/utils";
+// import { draftMode } from "next/headers";
 
 export async function generateMetadata() {
   const { data: result } = await sanityFetch({
     query: getSauceIndexPageQuery,
-    stega: false,
   });
 
   const data = result as SauceIndexPageData | null;
@@ -32,15 +32,11 @@ export async function generateMetadata() {
 }
 
 async function fetchSauces() {
-  return await handleErrors(
-    sanityFetch({ query: getAllSaucesForIndexQuery, stega: false }),
-  );
+  return await handleErrors(sanityFetch({ query: getAllSaucesForIndexQuery }));
 }
 
 async function fetchIndexCopy() {
-  return await handleErrors(
-    sanityFetch({ query: getSauceIndexPageQuery, stega: false }),
-  );
+  return await handleErrors(sanityFetch({ query: getSauceIndexPageQuery }));
 }
 
 export default async function SaucesIndexPage({
@@ -76,7 +72,6 @@ export default async function SaucesIndexPage({
         </div>
 
         <div className="mt-8">
-          {/* Client manages state; SSR computes same initial results to avoid flash */}
           <SaucesClient items={items} initialState={initialState} />
         </div>
       </div>

--- a/apps/web/src/app/sauces/page.tsx
+++ b/apps/web/src/app/sauces/page.tsx
@@ -43,7 +43,8 @@ async function fetchIndexCopy() {
 export default async function SaucesIndexPage({
   searchParams,
 }: {
-  searchParams?: Record<string, string | string[] | undefined>;
+  // Next.js 15: searchParams is now async and must be awaited
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const [saucesRes, copyRes] = await Promise.all([
     fetchSauces(),
@@ -56,11 +57,12 @@ export default async function SaucesIndexPage({
   const indexDoc = (copyData?.data ?? null) as SauceIndexPageData | null;
   const items = (saucesData?.data ?? []) as SauceListItem[];
 
-  const initialState: SauceQueryState = parseSearchParams(searchParams ?? {});
+  const resolvedSearchParams = (await searchParams) ?? {};
+  const initialState: SauceQueryState = parseSearchParams(resolvedSearchParams);
 
   return (
-    <main className="bg-background">
-      <div className="container my-16 mx-auto px-4 md:px-6">
+    <main>
+      <div className="container py-60 mx-auto px-4 md:px-6">
         <div className="mx-auto max-w-2xl text-center">
           <h1 className="text-3xl font-bold sm:text-4xl">
             {indexDoc?.title ?? "Sauces"}

--- a/apps/web/src/app/sauces/page.tsx
+++ b/apps/web/src/app/sauces/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import { SaucesClient } from "@/components/sauces/sauces-client";
@@ -12,7 +13,7 @@ import type { SauceIndexPageData, SauceListItem } from "@/types";
 import { handleErrors } from "@/utils";
 // import { draftMode } from "next/headers";
 
-export async function generateMetadata() {
+export async function generateMetadata(): Promise<Metadata> {
   const { data: result } = await sanityFetch({
     query: getSauceIndexPageQuery,
   });

--- a/apps/web/src/components/elements/sanity-image.tsx
+++ b/apps/web/src/components/elements/sanity-image.tsx
@@ -30,6 +30,7 @@ interface ProcessedImageData {
 
 type SanityImageProps = {
   readonly image: SanityImageData;
+  readonly respectSanityCrop?: boolean;
 } & Omit<WrapperProps<"img">, "id">;
 
 // Base URL construction
@@ -82,15 +83,18 @@ function hasPreview(preview: unknown): preview is string {
 }
 
 // Main image processing function
-function processImageData(image: SanityImageData): ProcessedImageData | null {
+function processImageData(
+  image: SanityImageData,
+  includeTransforms: boolean = true,
+): ProcessedImageData | null {
   // Early return for invalid image data
   if (!image?.id || typeof image.id !== "string") {
     console.warn("SanityImage: Invalid image data provided", image);
     return null;
   }
 
-  const hotspot = extractHotspot(image);
-  const crop = extractCrop(image);
+  const hotspot = includeTransforms ? extractHotspot(image) : undefined;
+  const crop = includeTransforms ? extractCrop(image) : undefined;
   const preview = hasPreview(image.preview) ? image.preview : undefined;
 
   return {
@@ -107,8 +111,12 @@ const ImageWrapper = <T extends React.ElementType = "img">(
 ) => <BaseSanityImage baseUrl={SANITY_BASE_URL} {...props} />;
 
 // Main component
-function SanityImageComponent({ image, ...props }: SanityImageProps) {
-  const processedImageData = processImageData(image);
+function SanityImageComponent({
+  image,
+  respectSanityCrop = true,
+  ...props
+}: SanityImageProps) {
+  const processedImageData = processImageData(image, respectSanityCrop);
 
   // Early return for invalid image data
   if (!processedImageData) {

--- a/apps/web/src/components/sauce-card.tsx
+++ b/apps/web/src/components/sauce-card.tsx
@@ -4,12 +4,7 @@ import Link from "next/link";
 import { stegaClean } from "next-sanity";
 
 import { SanityImage } from "@/components/elements/sanity-image";
-import {
-  getLineBadge,
-  getTypeBadge,
-  toLineSlug,
-  toTypeSlug,
-} from "@/config/sauce-taxonomy";
+import { getLineBadge, getTypeBadge } from "@/config/sauce-taxonomy";
 import type { SauceListItem } from "@/types";
 
 export function SauceCard({ item }: { item: SauceListItem }) {
@@ -50,12 +45,12 @@ export function SauceCard({ item }: { item: SauceListItem }) {
         <div className="flex items-center justify-center gap-2 mt-2">
           <Badge
             text={lineBadge.text}
-            variant={toLineSlug(line) ?? "neutral"}
+            variant={lineBadge.variant}
             className="text-xs"
           />
           <Badge
             text={typeBadge.text}
-            variant={toTypeSlug(category) ?? "neutral"}
+            variant={typeBadge.variant}
             className="text-xs"
           />
         </div>

--- a/apps/web/src/components/sauce-card.tsx
+++ b/apps/web/src/components/sauce-card.tsx
@@ -15,19 +15,21 @@ export function SauceCard({ item }: { item: SauceListItem }) {
     <Link
       href={`/sauces/${slug}`}
       aria-label={`View ${name} sauce`}
-      className="group block focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-xl overflow-hidden border border-border shadow-sm transition hover:shadow-md"
+      className="group block focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-xl"
     >
-      <div className="relative">
+      <div className="aspect-[1/1] flex items-center justify-center p-4">
         {mainImage?.id ? (
           <SanityImage
             image={mainImage}
-            width={600}
-            height={600}
+            respectSanityCrop={false}
+            width={200}
+            height={400}
             alt={mainImage?.alt ?? `${name} sauce`}
-            className="w-full aspect-square object-cover"
+            className="max-h-full max-w-full object-contain"
+            style={{ objectFit: "contain" }}
           />
         ) : (
-          <div className="w-full aspect-square bg-muted" />
+          <div className="h-full w-full bg-muted" />
         )}
       </div>
 

--- a/apps/web/src/components/sauce-card.tsx
+++ b/apps/web/src/components/sauce-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { Badge } from "@workspace/ui/components/badge";
 import Link from "next/link";
+import { stegaClean } from "next-sanity";
 
 import { SanityImage } from "@/components/elements/sanity-image";
 import {
@@ -15,21 +16,24 @@ export function SauceCard({ item }: { item: SauceListItem }) {
   const { name, slug, mainImage, line, category } = item;
   const lineBadge = getLineBadge(line);
   const typeBadge = getTypeBadge(category);
+  // Clean non-visible a11y strings from Sanity stega metadata
+  const a11yName = stegaClean(name);
+  const altText = stegaClean(mainImage?.alt ?? `${a11yName} sauce`);
 
   return (
     <Link
       href={`/sauces/${slug}`}
-      aria-label={`View ${name} sauce`}
+      aria-label={`View ${a11yName} sauce`}
       className="group block focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-xl"
     >
-      <div className="aspect-[1/1] flex items-center justify-center p-4">
+      <div className="aspect-[33/40] flex items-center justify-center p-4">
         {mainImage?.id ? (
           <SanityImage
             image={mainImage}
             respectSanityCrop={false}
             width={200}
             height={400}
-            alt={mainImage?.alt ?? `${name} sauce`}
+            alt={altText}
             className="max-h-full max-w-full object-contain"
             style={{ objectFit: "contain" }}
           />

--- a/apps/web/src/components/sauce-card.tsx
+++ b/apps/web/src/components/sauce-card.tsx
@@ -26,7 +26,7 @@ export function SauceCard({ item }: { item: SauceListItem }) {
       aria-label={`View ${a11yName} sauce`}
       className="group block focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-xl"
     >
-      <div className="aspect-[33/40] flex items-center justify-center p-4">
+      <div className="aspect-[33/40] flex items-center justify-center">
         {mainImage?.id ? (
           <SanityImage
             image={mainImage}
@@ -43,7 +43,7 @@ export function SauceCard({ item }: { item: SauceListItem }) {
       </div>
 
       <div className="p-4">
-        <div className="flex items-center gap-2 mb-2">
+        <div className="flex items-center justify-center gap-2 mb-2">
           <Badge
             text={lineBadge.text}
             variant={toLineSlug(line) ?? "neutral"}
@@ -56,7 +56,7 @@ export function SauceCard({ item }: { item: SauceListItem }) {
           />
         </div>
 
-        <h3 className="text-base font-semibold leading-tight group-hover:underline">
+        <h3 className="text-base font-semibold leading-tight group-hover:underline text-center">
           {name}
         </h3>
       </div>

--- a/apps/web/src/components/sauce-card.tsx
+++ b/apps/web/src/components/sauce-card.tsx
@@ -3,7 +3,12 @@ import { Badge } from "@workspace/ui/components/badge";
 import Link from "next/link";
 
 import { SanityImage } from "@/components/elements/sanity-image";
-import { getLineBadge, getTypeBadge } from "@/config/sauce-taxonomy";
+import {
+  getLineBadge,
+  getTypeBadge,
+  toLineSlug,
+  toTypeSlug,
+} from "@/config/sauce-taxonomy";
 import type { SauceListItem } from "@/types";
 
 export function SauceCard({ item }: { item: SauceListItem }) {
@@ -36,23 +41,15 @@ export function SauceCard({ item }: { item: SauceListItem }) {
       <div className="p-4">
         <div className="flex items-center gap-2 mb-2">
           <Badge
+            text={lineBadge.text}
+            variant={toLineSlug(line) ?? "neutral"}
             className="text-xs"
-            style={{
-              background: `var(${lineBadge.colorVar})`,
-              color: "white",
-            }}
-          >
-            {lineBadge.text}
-          </Badge>
+          />
           <Badge
+            text={typeBadge.text}
+            variant={toTypeSlug(category) ?? "neutral"}
             className="text-xs"
-            style={{
-              background: `var(${typeBadge.colorVar || "--color-th-neutral-300"})`,
-              color: typeBadge.colorVar ? "black" : "black",
-            }}
-          >
-            {typeBadge.text}
-          </Badge>
+          />
         </div>
 
         <h3 className="text-base font-semibold leading-tight group-hover:underline">

--- a/apps/web/src/components/sauce-card.tsx
+++ b/apps/web/src/components/sauce-card.tsx
@@ -1,0 +1,62 @@
+"use client";
+import { Badge } from "@workspace/ui/components/badge";
+import Link from "next/link";
+
+import { SanityImage } from "@/components/elements/sanity-image";
+import { getLineBadge, getTypeBadge } from "@/config/sauce-taxonomy";
+import type { SauceListItem } from "@/types";
+
+export function SauceCard({ item }: { item: SauceListItem }) {
+  const { name, slug, mainImage, line, category } = item;
+  const lineBadge = getLineBadge(line);
+  const typeBadge = getTypeBadge(category);
+
+  return (
+    <Link
+      href={`/sauces/${slug}`}
+      aria-label={`View ${name} sauce`}
+      className="group block focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-xl overflow-hidden border border-border shadow-sm transition hover:shadow-md"
+    >
+      <div className="relative">
+        {mainImage?.id ? (
+          <SanityImage
+            image={mainImage}
+            width={600}
+            height={600}
+            alt={mainImage?.alt ?? `${name} sauce`}
+            className="w-full aspect-square object-cover"
+          />
+        ) : (
+          <div className="w-full aspect-square bg-muted" />
+        )}
+      </div>
+
+      <div className="p-4">
+        <div className="flex items-center gap-2 mb-2">
+          <Badge
+            className="text-xs"
+            style={{
+              background: `var(${lineBadge.colorVar})`,
+              color: "white",
+            }}
+          >
+            {lineBadge.text}
+          </Badge>
+          <Badge
+            className="text-xs"
+            style={{
+              background: `var(${typeBadge.colorVar || "--color-th-neutral-300"})`,
+              color: typeBadge.colorVar ? "black" : "black",
+            }}
+          >
+            {typeBadge.text}
+          </Badge>
+        </div>
+
+        <h3 className="text-base font-semibold leading-tight group-hover:underline">
+          {name}
+        </h3>
+      </div>
+    </Link>
+  );
+}

--- a/apps/web/src/components/sauce-card.tsx
+++ b/apps/web/src/components/sauce-card.tsx
@@ -43,7 +43,11 @@ export function SauceCard({ item }: { item: SauceListItem }) {
       </div>
 
       <div className="p-4">
-        <div className="flex items-center justify-center gap-2 mb-2">
+        <h3 className="text-base font-semibold leading-tight group-hover:underline text-center">
+          {name}
+        </h3>
+
+        <div className="flex items-center justify-center gap-2 mt-2">
           <Badge
             text={lineBadge.text}
             variant={toLineSlug(line) ?? "neutral"}
@@ -55,10 +59,6 @@ export function SauceCard({ item }: { item: SauceListItem }) {
             className="text-xs"
           />
         </div>
-
-        <h3 className="text-base font-semibold leading-tight group-hover:underline text-center">
-          {name}
-        </h3>
       </div>
     </Link>
   );

--- a/apps/web/src/components/sauces/sauces-client.tsx
+++ b/apps/web/src/components/sauces/sauces-client.tsx
@@ -264,7 +264,8 @@ export function SaucesClient({ items, initialState }: Props) {
     <div className="grid grid-cols-1 lg:grid-cols-[280px_1fr] gap-8">
       {/* Sidebar (desktop) */}
       <aside className="hidden lg:block">
-        <div className="sticky top-20 space-y-6">
+        {/* Offset the sticky sidebar so it doesn't collide with the fixed header */}
+        <div className="sticky top-32 space-y-6">
           <FiltersForm
             idPrefix="desktop"
             search={search}

--- a/apps/web/src/components/sauces/sauces-client.tsx
+++ b/apps/web/src/components/sauces/sauces-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { Button } from "@workspace/ui/components/button";
+import { Checkbox } from "@workspace/ui/components/checkbox";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -8,6 +9,10 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from "@workspace/ui/components/dropdown-menu";
+import {
+  RadioGroup,
+  RadioGroupItem,
+} from "@workspace/ui/components/radio-group";
 import {
   Sheet,
   SheetClose,
@@ -73,7 +78,7 @@ function FiltersForm({
             type="search"
             value={search}
             onChange={(e) => setSearch(e.currentTarget.value)}
-            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            className="w-full rounded-md border border-input bg-white/70 px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             placeholder="Search by name or description"
             aria-label="Search sauces"
           />
@@ -89,8 +94,10 @@ function FiltersForm({
         </div>
       </div>
 
-      <fieldset className="border rounded-md p-4">
-        <legend className="px-1 text-xl font-medium">Product Line</legend>
+      <fieldset className="rounded-lg border border-th-brown-400/30 bg-th-light-100/30 p-4 shadow-sm">
+        <legend className="-ms-1 px-2 text-lg font-semibold text-th-dark-900">
+          Product Line
+        </legend>
         <div className="mt-2 grid grid-cols-1 gap-2">
           {allLineSlugs.map((slug) => {
             const id = `${idPrefix}-line-${slug}`;
@@ -102,12 +109,10 @@ function FiltersForm({
                 htmlFor={id}
                 className="flex items-center gap-2"
               >
-                <input
+                <Checkbox
                   id={id}
-                  type="checkbox"
                   checked={checked}
-                  onChange={() => toggleLine(slug)}
-                  className="size-4 rounded-sm border border-input focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+                  onCheckedChange={() => toggleLine(slug)}
                   aria-label={cfg.display}
                 />
                 <span>{cfg.display}</span>
@@ -124,44 +129,45 @@ function FiltersForm({
         ) : null}
       </fieldset>
 
-      <fieldset className="border rounded-md p-4">
-        <legend className="px-1 text-xl font-medium">Sauce Type</legend>
+      <fieldset className="rounded-lg border border-th-brown-400/30 bg-th-light-100/30 p-4 shadow-sm">
+        <legend className="-ms-1 px-2 text-lg font-semibold text-th-dark-900">
+          Sauce Type
+        </legend>
         <div className="mt-2 grid grid-cols-1 gap-2">
-          <label className="flex items-center gap-2">
-            <input
-              type="radio"
-              name={`${idPrefix}-sauce-type`}
-              value="all"
-              checked={sauceType === "all"}
-              onChange={() => setSauceType("all")}
-              className="size-4 rounded-full border border-input focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
-              aria-label="All"
-            />
-            <span>All</span>
-          </label>
-          {allTypeSlugs.map((slug) => {
-            const id = `${idPrefix}-type-${slug}`;
-            const cfg = typeMap[slug];
-            return (
-              <label
-                key={slug}
-                htmlFor={id}
-                className="flex items-center gap-2"
-              >
-                <input
-                  id={id}
-                  type="radio"
-                  name={`${idPrefix}-sauce-type`}
-                  value={slug}
-                  checked={sauceType === slug}
-                  onChange={() => setSauceType(slug)}
-                  className="size-4 rounded-full border border-input focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
-                  aria-label={cfg.display}
-                />
-                <span>{cfg.display}</span>
-              </label>
-            );
-          })}
+          <RadioGroup
+            value={sauceType}
+            onValueChange={(v: SauceQueryState["sauceType"]) => setSauceType(v)}
+          >
+            <label
+              className="flex items-center gap-2"
+              htmlFor={`${idPrefix}-sauce-type-all`}
+            >
+              <RadioGroupItem
+                id={`${idPrefix}-sauce-type-all`}
+                value="all"
+                aria-label="All"
+              />
+              <span>All</span>
+            </label>
+            {allTypeSlugs.map((slug) => {
+              const id = `${idPrefix}-type-${slug}`;
+              const cfg = typeMap[slug];
+              return (
+                <label
+                  key={slug}
+                  htmlFor={id}
+                  className="flex items-center gap-2"
+                >
+                  <RadioGroupItem
+                    id={id}
+                    value={slug}
+                    aria-label={cfg.display}
+                  />
+                  <span>{cfg.display}</span>
+                </label>
+              );
+            })}
+          </RadioGroup>
         </div>
         {sauceType !== "all" ? (
           <div className="mt-2">
@@ -288,7 +294,7 @@ export function SaucesClient({ items, initialState }: Props) {
           <div
             aria-live="polite"
             aria-atomic="true"
-            className="text-sm text-muted-foreground"
+            className="text-muted-foreground"
           >
             {firstPaint
               ? `Showing ${

--- a/apps/web/src/components/sauces/sauces-client.tsx
+++ b/apps/web/src/components/sauces/sauces-client.tsx
@@ -378,7 +378,7 @@ export function SaucesClient({ items, initialState }: Props) {
             </Button>
           </div>
         ) : (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3  gap-y-12">
             {(firstPaint
               ? applyFiltersAndSort(items, initialState)
               : results

--- a/apps/web/src/components/sauces/sauces-client.tsx
+++ b/apps/web/src/components/sauces/sauces-client.tsx
@@ -67,6 +67,8 @@ function FiltersForm({
   clearSauceType,
 }: FiltersFormProps) {
   const searchId = `${idPrefix}-sauce-search`;
+  // Unified styling for desktop and mobile: remove card borders and use simple section dividers
+  const legendClass = "px-0 text-lg font-semibold";
   return (
     <div className="space-y-6">
       <div>
@@ -95,10 +97,8 @@ function FiltersForm({
         </div>
       </div>
 
-      <fieldset className="rounded-lg border border-th-brown-400/30 bg-th-light-100/30 p-4 shadow-sm">
-        <legend className="-ms-1 px-2 text-lg font-semibold text-th-dark-900">
-          Product Line
-        </legend>
+      <fieldset className="m-0 border-0 p-0 mt-6 pb-6">
+        <legend className={legendClass}>Product Line</legend>
         <div className="mt-2 grid grid-cols-1 gap-2">
           {allLineSlugs.map((slug) => {
             const id = `${idPrefix}-line-${slug}`;
@@ -130,10 +130,8 @@ function FiltersForm({
         ) : null}
       </fieldset>
 
-      <fieldset className="rounded-lg border border-th-brown-400/30 bg-th-light-100/30 p-4 shadow-sm">
-        <legend className="-ms-1 px-2 text-lg font-semibold text-th-dark-900">
-          Sauce Type
-        </legend>
+      <fieldset className="m-0 border-0 p-0 border-t border-border/80 pt-6 pb-6">
+        <legend className={legendClass}>Sauce Type</legend>
         <div className="mt-2 grid grid-cols-1 gap-2">
           <RadioGroup
             value={sauceType}
@@ -306,7 +304,7 @@ export function SaucesClient({ items, initialState }: Props) {
                   <SheetTitle>Filters</SheetTitle>
                   <SheetDescription>Refine the list of sauces</SheetDescription>
                 </SheetHeader>
-                <div className="mt-4 overflow-y-auto pb-24">
+                <div className="mt-2 overflow-y-auto px-4 pb-24">
                   <FiltersForm
                     idPrefix="sheet"
                     search={search}

--- a/apps/web/src/components/sauces/sauces-client.tsx
+++ b/apps/web/src/components/sauces/sauces-client.tsx
@@ -2,6 +2,15 @@
 import { Button } from "@workspace/ui/components/button";
 import { Checkbox } from "@workspace/ui/components/checkbox";
 import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@workspace/ui/components/drawer";
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuLabel,
@@ -13,16 +22,6 @@ import {
   RadioGroup,
   RadioGroupItem,
 } from "@workspace/ui/components/radio-group";
-import {
-  Sheet,
-  SheetClose,
-  SheetContent,
-  SheetDescription,
-  SheetFooter,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
-} from "@workspace/ui/components/sheet";
 import { Filter } from "lucide-react";
 import { usePathname } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
@@ -242,7 +241,7 @@ export function SaucesClient({ items, initialState }: Props) {
   }, []);
 
   // A11y live region and count display: "Showing X of Y"
-  const resultsText = `Showing ${results.length} of ${items.length}`;
+  const resultsText = `${results.length} of ${items.length}`;
 
   function clearAll() {
     setSearch("");
@@ -289,21 +288,20 @@ export function SaucesClient({ items, initialState }: Props) {
       {/* Main content */}
       <section className="min-w-0">
         {/* Top bar */}
-        <div className="mb-4 flex items-center gap-2">
+        <div className="mb-8 md:mb-12 flex items-center gap-2">
           {/* Mobile filter button first on the left */}
           <div className="lg:hidden">
-            <Sheet>
-              <SheetTrigger asChild>
+            <Drawer>
+              <DrawerTrigger asChild>
                 <Button type="button" variant="secondary">
                   <Filter className="me-2 size-4" aria-hidden="true" />
                   Filters
                 </Button>
-              </SheetTrigger>
-              <SheetContent side="left" className="w-80">
-                <SheetHeader>
-                  <SheetTitle>Filters</SheetTitle>
-                  <SheetDescription>Refine the list of sauces</SheetDescription>
-                </SheetHeader>
+              </DrawerTrigger>
+              <DrawerContent>
+                <DrawerHeader>
+                  <DrawerTitle>Filters</DrawerTitle>
+                </DrawerHeader>
                 <div className="mt-2 overflow-y-auto px-4 pb-24">
                   <FiltersForm
                     idPrefix="sheet"
@@ -317,16 +315,16 @@ export function SaucesClient({ items, initialState }: Props) {
                     clearProductLine={clearProductLine}
                     clearSauceType={clearSauceType}
                     applyButton={
-                      <SheetFooter>
-                        <SheetClose asChild>
+                      <DrawerFooter>
+                        <DrawerClose asChild>
                           <Button type="button">Apply</Button>
-                        </SheetClose>
-                      </SheetFooter>
+                        </DrawerClose>
+                      </DrawerFooter>
                     }
                   />
                 </div>
-              </SheetContent>
-            </Sheet>
+              </DrawerContent>
+            </Drawer>
           </div>
 
           {/* Live results text */}

--- a/apps/web/src/components/sauces/sauces-client.tsx
+++ b/apps/web/src/components/sauces/sauces-client.tsx
@@ -64,8 +64,8 @@ function FiltersForm({
   return (
     <div className="space-y-6">
       <div>
-        <label htmlFor={searchId} className="block text-sm font-medium">
-          Search sauces
+        <label htmlFor={searchId} className="block text-xl font-medium">
+          Search
         </label>
         <div className="mt-2 flex items-center gap-2">
           <input
@@ -90,7 +90,7 @@ function FiltersForm({
       </div>
 
       <fieldset className="border rounded-md p-4">
-        <legend className="px-1 text-sm font-medium">Product Line</legend>
+        <legend className="px-1 text-xl font-medium">Product Line</legend>
         <div className="mt-2 grid grid-cols-1 gap-2">
           {allLineSlugs.map((slug) => {
             const id = `${idPrefix}-line-${slug}`;
@@ -125,7 +125,7 @@ function FiltersForm({
       </fieldset>
 
       <fieldset className="border rounded-md p-4">
-        <legend className="px-1 text-sm font-medium">Sauce Type</legend>
+        <legend className="px-1 text-xl font-medium">Sauce Type</legend>
         <div className="mt-2 grid grid-cols-1 gap-2">
           <label className="flex items-center gap-2">
             <input
@@ -236,8 +236,8 @@ export function SaucesClient({ items, initialState }: Props) {
     setFirstPaint(false);
   }, []);
 
-  // A11y live region
-  const resultsText = `${results.length} result${results.length === 1 ? "" : "s"}`;
+  // A11y live region and count display: "Showing X of Y"
+  const resultsText = `Showing ${results.length} of ${items.length}`;
 
   function clearAll() {
     setSearch("");
@@ -290,13 +290,11 @@ export function SaucesClient({ items, initialState }: Props) {
             className="text-sm text-muted-foreground"
           >
             {firstPaint
-              ? `${initialState ? applyFiltersAndSort(items, initialState).length : results.length} result${
-                  (initialState
+              ? `Showing ${
+                  initialState
                     ? applyFiltersAndSort(items, initialState).length
-                    : results.length) === 1
-                    ? ""
-                    : "s"
-                }`
+                    : results.length
+                } of ${items.length}`
               : resultsText}
           </div>
 

--- a/apps/web/src/components/sauces/sauces-client.tsx
+++ b/apps/web/src/components/sauces/sauces-client.tsx
@@ -80,6 +80,11 @@ export function SaucesClient({ items, initialState }: Props) {
     () => applyFiltersAndSort(items, state),
     [items, state],
   );
+  // Avoid hydration flash: use SSR-computed initial results for first paint
+  const [firstPaint, setFirstPaint] = useState(true);
+  useEffect(() => {
+    setFirstPaint(false);
+  }, []);
 
   // A11y live region
   const resultsText = `${results.length} result${results.length === 1 ? "" : "s"}`;
@@ -245,7 +250,15 @@ export function SaucesClient({ items, initialState }: Props) {
             aria-atomic="true"
             className="text-sm text-muted-foreground"
           >
-            {resultsText}
+            {firstPaint
+              ? `${initialState ? applyFiltersAndSort(items, initialState).length : results.length} result${
+                  (initialState
+                    ? applyFiltersAndSort(items, initialState).length
+                    : results.length) === 1
+                    ? ""
+                    : "s"
+                }`
+              : resultsText}
           </div>
 
           <div className="flex items-center gap-2">
@@ -305,7 +318,8 @@ export function SaucesClient({ items, initialState }: Props) {
         </div>
 
         {/* Grid */}
-        {results.length === 0 ? (
+        {(firstPaint ? applyFiltersAndSort(items, initialState) : results)
+          .length === 0 ? (
           <div className="text-center py-12">
             <p className="text-muted-foreground mb-4">
               No sauces match your filters.
@@ -316,7 +330,10 @@ export function SaucesClient({ items, initialState }: Props) {
           </div>
         ) : (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-            {results.map((item) => (
+            {(firstPaint
+              ? applyFiltersAndSort(items, initialState)
+              : results
+            ).map((item) => (
               <SauceCard key={item._id} item={item} />
             ))}
           </div>

--- a/apps/web/src/components/sauces/sauces-client.tsx
+++ b/apps/web/src/components/sauces/sauces-client.tsx
@@ -23,6 +23,7 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@workspace/ui/components/sheet";
+import { Filter } from "lucide-react";
 import { usePathname } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 
@@ -290,11 +291,51 @@ export function SaucesClient({ items, initialState }: Props) {
       {/* Main content */}
       <section className="min-w-0">
         {/* Top bar */}
-        <div className="flex items-center justify-between mb-4">
+        <div className="mb-4 flex items-center gap-2">
+          {/* Mobile filter button first on the left */}
+          <div className="lg:hidden">
+            <Sheet>
+              <SheetTrigger asChild>
+                <Button type="button" variant="secondary">
+                  <Filter className="me-2 size-4" aria-hidden="true" />
+                  Filters
+                </Button>
+              </SheetTrigger>
+              <SheetContent side="left" className="w-80">
+                <SheetHeader>
+                  <SheetTitle>Filters</SheetTitle>
+                  <SheetDescription>Refine the list of sauces</SheetDescription>
+                </SheetHeader>
+                <div className="mt-4 overflow-y-auto pb-24">
+                  <FiltersForm
+                    idPrefix="sheet"
+                    search={search}
+                    setSearch={setSearch}
+                    productLine={productLine}
+                    toggleLine={toggleLine}
+                    sauceType={sauceType}
+                    setSauceType={setSauceType}
+                    clearAll={clearAll}
+                    clearProductLine={clearProductLine}
+                    clearSauceType={clearSauceType}
+                    applyButton={
+                      <SheetFooter>
+                        <SheetClose asChild>
+                          <Button type="button">Apply</Button>
+                        </SheetClose>
+                      </SheetFooter>
+                    }
+                  />
+                </div>
+              </SheetContent>
+            </Sheet>
+          </div>
+
+          {/* Live results text */}
           <div
             aria-live="polite"
             aria-atomic="true"
-            className="text-muted-foreground"
+            className="flex-1 text-muted-foreground"
           >
             {firstPaint
               ? `Showing ${
@@ -305,70 +346,24 @@ export function SaucesClient({ items, initialState }: Props) {
               : resultsText}
           </div>
 
-          <div className="flex items-center gap-2">
-            {/* Mobile filter button */}
-            <div className="lg:hidden">
-              <Sheet>
-                <SheetTrigger asChild>
-                  <Button type="button" variant="secondary">
-                    Filters
-                  </Button>
-                </SheetTrigger>
-                <SheetContent side="left" className="w-80">
-                  <SheetHeader>
-                    <SheetTitle>Filters</SheetTitle>
-                    <SheetDescription>
-                      Refine the list of sauces
-                    </SheetDescription>
-                  </SheetHeader>
-                  <div className="mt-4 overflow-y-auto pb-24">
-                    <FiltersForm
-                      idPrefix="sheet"
-                      search={search}
-                      setSearch={setSearch}
-                      productLine={productLine}
-                      toggleLine={toggleLine}
-                      sauceType={sauceType}
-                      setSauceType={setSauceType}
-                      clearAll={clearAll}
-                      clearProductLine={clearProductLine}
-                      clearSauceType={clearSauceType}
-                      applyButton={
-                        <SheetFooter>
-                          <SheetClose asChild>
-                            <Button type="button">Apply</Button>
-                          </SheetClose>
-                        </SheetFooter>
-                      }
-                    />
-                  </div>
-                </SheetContent>
-              </Sheet>
-            </div>
-
-            {/* Sort dropdown */}
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button type="button" variant="secondary">
-                  Sort
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuLabel>Sort by name</DropdownMenuLabel>
-                <DropdownMenuRadioGroup
-                  value={sort}
-                  onValueChange={(v) => setSort((v as SortOrder) ?? "az")}
-                >
-                  <DropdownMenuRadioItem value="az">
-                    A → Z
-                  </DropdownMenuRadioItem>
-                  <DropdownMenuRadioItem value="za">
-                    Z → A
-                  </DropdownMenuRadioItem>
-                </DropdownMenuRadioGroup>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
+          {/* Sort dropdown on the right */}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button type="button" variant="secondary" className="ms-auto">
+                Sort
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuLabel>Sort by name</DropdownMenuLabel>
+              <DropdownMenuRadioGroup
+                value={sort}
+                onValueChange={(v) => setSort((v as SortOrder) ?? "az")}
+              >
+                <DropdownMenuRadioItem value="az">A → Z</DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="za">Z → A</DropdownMenuRadioItem>
+              </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
 
         {/* Grid */}

--- a/apps/web/src/components/sections/cta.tsx
+++ b/apps/web/src/components/sections/cta.tsx
@@ -14,9 +14,7 @@ export function CTABlock({ richText, title, eyebrow, buttons }: CTABlockProps) {
         <div className="bg-muted py-16 rounded-3xl px-4">
           <div className="text-center max-w-3xl mx-auto space-y-8">
             {eyebrow && (
-              <Badge variant="secondary" className="bg-zinc-200">
-                {eyebrow}
-              </Badge>
+              <Badge text={eyebrow} variant="neutral" className="bg-zinc-200" />
             )}
             <h2 className="text-3xl font-semibold md:text-5xl text-balance">
               {title}

--- a/apps/web/src/components/sections/cta.tsx
+++ b/apps/web/src/components/sections/cta.tsx
@@ -1,4 +1,4 @@
-import { Badge } from "@workspace/ui/components/badge";
+import { Eyebrow } from "@workspace/ui/components/eyebrow";
 
 import type { PagebuilderType } from "@/types";
 
@@ -13,9 +13,7 @@ export function CTABlock({ richText, title, eyebrow, buttons }: CTABlockProps) {
       <div className="container mx-auto px-4 md:px-8">
         <div className="bg-muted py-16 rounded-3xl px-4">
           <div className="text-center max-w-3xl mx-auto space-y-8">
-            {eyebrow && (
-              <Badge text={eyebrow} variant="neutral" className="bg-zinc-200" />
-            )}
+            {eyebrow && <Eyebrow text={eyebrow} />}
             <h2 className="text-3xl font-semibold md:text-5xl text-balance">
               {title}
             </h2>

--- a/apps/web/src/components/sections/faq-accordion.tsx
+++ b/apps/web/src/components/sections/faq-accordion.tsx
@@ -27,7 +27,7 @@ export function FaqAccordion({
       <div className="container mx-auto px-4 md:px-6">
         <div className="flex w-full flex-col items-center">
           <div className="flex flex-col items-center space-y-4 text-center sm:space-y-6 md:text-center">
-            <Badge variant="secondary">{eyebrow}</Badge>
+            <Badge text={eyebrow ?? ""} variant="neutral" />
             <h2 className="text-3xl font-semibold md:text-5xl">{title}</h2>
             <h3 className="text-lg font-normal text-[#374151] text-balance">
               {subtitle}

--- a/apps/web/src/components/sections/faq-accordion.tsx
+++ b/apps/web/src/components/sections/faq-accordion.tsx
@@ -4,7 +4,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@workspace/ui/components/accordion";
-import { Badge } from "@workspace/ui/components/badge";
+import { Eyebrow } from "@workspace/ui/components/eyebrow";
 import { ArrowUpRight } from "lucide-react";
 import Link from "next/link";
 
@@ -27,7 +27,7 @@ export function FaqAccordion({
       <div className="container mx-auto px-4 md:px-6">
         <div className="flex w-full flex-col items-center">
           <div className="flex flex-col items-center space-y-4 text-center sm:space-y-6 md:text-center">
-            <Badge text={eyebrow ?? ""} variant="neutral" />
+            <Eyebrow text={eyebrow ?? ""} />
             <h2 className="text-3xl font-semibold md:text-5xl">{title}</h2>
             <h3 className="text-lg font-normal text-[#374151] text-balance">
               {subtitle}

--- a/apps/web/src/components/sections/feature-cards-with-icon.tsx
+++ b/apps/web/src/components/sections/feature-cards-with-icon.tsx
@@ -1,4 +1,4 @@
-import { Badge } from "@workspace/ui/components/badge";
+import { Eyebrow } from "@workspace/ui/components/eyebrow";
 
 import type { PagebuilderType } from "@/types";
 
@@ -41,7 +41,7 @@ export function FeatureCardsWithIcon({
       <div className="container mx-auto px-4 md:px-6">
         <div className="flex w-full flex-col items-center">
           <div className="flex flex-col items-center space-y-4 text-center sm:space-y-6 md:text-center">
-            <Badge text={eyebrow ?? ""} variant="neutral" />
+            <Eyebrow text={eyebrow ?? ""} />
             <h2 className="text-3xl font-semibold md:text-5xl">{title}</h2>
             <RichText
               richText={richText}

--- a/apps/web/src/components/sections/feature-cards-with-icon.tsx
+++ b/apps/web/src/components/sections/feature-cards-with-icon.tsx
@@ -41,7 +41,7 @@ export function FeatureCardsWithIcon({
       <div className="container mx-auto px-4 md:px-6">
         <div className="flex w-full flex-col items-center">
           <div className="flex flex-col items-center space-y-4 text-center sm:space-y-6 md:text-center">
-            <Badge variant="secondary">{eyebrow}</Badge>
+            <Badge text={eyebrow ?? ""} variant="neutral" />
             <h2 className="text-3xl font-semibold md:text-5xl">{title}</h2>
             <RichText
               richText={richText}

--- a/apps/web/src/components/sections/hero.tsx
+++ b/apps/web/src/components/sections/hero.tsx
@@ -1,4 +1,4 @@
-import { Badge } from "@workspace/ui/components/badge";
+import { Eyebrow } from "@workspace/ui/components/eyebrow";
 
 import type { PagebuilderType } from "@/types";
 
@@ -20,7 +20,7 @@ export function HeroBlock({
       <div className="container mx-auto px-4 md:px-6">
         <div className="grid items-center gap-8 lg:grid-cols-2">
           <div className="grid h-full grid-rows-[auto_1fr_auto] gap-4 items-center justify-items-center text-center lg:items-start lg:justify-items-start lg:text-left">
-            <Badge text={badge ?? ""} variant="neutral" />
+            <Eyebrow text={badge ?? ""} />
             <div className="grid gap-4">
               <h1 className="text-4xl lg:text-6xl font-semibold text-balance">
                 {title}

--- a/apps/web/src/components/sections/hero.tsx
+++ b/apps/web/src/components/sections/hero.tsx
@@ -20,7 +20,7 @@ export function HeroBlock({
       <div className="container mx-auto px-4 md:px-6">
         <div className="grid items-center gap-8 lg:grid-cols-2">
           <div className="grid h-full grid-rows-[auto_1fr_auto] gap-4 items-center justify-items-center text-center lg:items-start lg:justify-items-start lg:text-left">
-            <Badge variant="secondary">{badge}</Badge>
+            <Badge text={badge ?? ""} variant="neutral" />
             <div className="grid gap-4">
               <h1 className="text-4xl lg:text-6xl font-semibold text-balance">
                 {title}

--- a/apps/web/src/components/sections/image-link-cards.tsx
+++ b/apps/web/src/components/sections/image-link-cards.tsx
@@ -1,4 +1,4 @@
-import { Badge } from "@workspace/ui/components/badge";
+import { Eyebrow } from "@workspace/ui/components/eyebrow";
 import { cn } from "@workspace/ui/lib/utils";
 
 import type { PagebuilderType } from "@/types";
@@ -19,7 +19,7 @@ export function ImageLinkCards({
       <div className="container mx-auto px-4 md:px-6">
         <div className="flex w-full flex-col items-center">
           <div className="flex flex-col items-center space-y-4 text-center sm:space-y-6 md:text-center">
-            <Badge text={eyebrow ?? ""} variant="neutral" />
+            <Eyebrow text={eyebrow ?? ""} />
             <h2 className="text-3xl font-semibold md:text-5xl text-balance">
               {title}
             </h2>

--- a/apps/web/src/components/sections/image-link-cards.tsx
+++ b/apps/web/src/components/sections/image-link-cards.tsx
@@ -19,7 +19,7 @@ export function ImageLinkCards({
       <div className="container mx-auto px-4 md:px-6">
         <div className="flex w-full flex-col items-center">
           <div className="flex flex-col items-center space-y-4 text-center sm:space-y-6 md:text-center">
-            <Badge variant="secondary">{eyebrow}</Badge>
+            <Badge text={eyebrow ?? ""} variant="neutral" />
             <h2 className="text-3xl font-semibold md:text-5xl text-balance">
               {title}
             </h2>

--- a/apps/web/src/config/sauce-taxonomy.ts
+++ b/apps/web/src/config/sauce-taxonomy.ts
@@ -14,19 +14,21 @@ export type TypeLabel =
 
 export interface BadgeConfig {
   readonly text: string;
-  readonly colorVar: string; // CSS variable name, e.g. --color-th-green-500
+  /**
+   * Visual variant key expected by the shared <Badge /> component.
+   * Typically the canonical slug (e.g., "original", "organic", "pizza").
+   */
+  readonly variant: "neutral" | LineSlug | TypeSlug;
 }
 
 interface LineConfigItem {
   readonly label: LineLabel;
   readonly display: string;
-  readonly colorVar: string;
 }
 
 interface TypeConfigItem {
   readonly label: TypeLabel;
   readonly display: string;
-  readonly colorVar: string;
 }
 
 /**
@@ -40,17 +42,14 @@ export const lineMap: Record<LineSlug, LineConfigItem> = {
   original: {
     label: "Original",
     display: "Original",
-    colorVar: "--color-th-red-600",
   },
   organic: {
     label: "Organic",
     display: "Organic",
-    colorVar: "--color-th-green-500",
   },
   premium: {
     label: "Ultra-Premium",
     display: "Premium",
-    colorVar: "--color-th-dark-900",
   },
 } as const;
 
@@ -65,22 +64,18 @@ export const typeMap: Record<TypeSlug, TypeConfigItem> = {
   pasta: {
     label: "Pasta Sauce",
     display: "Pasta Sauce",
-    colorVar: "--color-brand-red",
   },
   pizza: {
     label: "Pizza Sauce",
     display: "Pizza Sauce",
-    colorVar: "--color-brand-yellow",
   },
   salsa: {
     label: "Salsa Sauce",
     display: "Salsa Sauce",
-    colorVar: "--color-brand-green",
   },
   sandwich: {
     label: "Sandwich Sauce",
     display: "Sandwich Sauce",
-    colorVar: "",
   },
 } as const;
 
@@ -176,41 +171,47 @@ export function fromTypeSlug(slug: TypeSlug): TypeLabel {
 /**
  * Derive a badge configuration for a product line label.
  *
- * Returns a stable `text` and `colorVar` used by the shared `<Badge />`
- * component. Falls back to a neutral badge when the label is unknown.
+ * Returns a stable `text` and `variant` used by the shared `<Badge />`
+ * component (CVA variants). Falls back to a neutral badge when unknown.
  *
  * Examples:
- * - getLineBadge("Organic") -> { text: "Organic", colorVar: "--color-th-green-500" }
- * - getLineBadge("Unknown Line") -> { text: "Unknown Line", colorVar: "" }
+ * - getLineBadge("Organic") -> { text: "Organic", variant: "organic" }
+ * - getLineBadge("Unknown Line") -> { text: "Unknown Line", variant: "neutral" }
  */
 export function getLineBadge(label: unknown): BadgeConfig {
   const slug = toLineSlug(label);
   const cfg = slug ? lineMap[slug] : undefined;
   if (!cfg) {
     const text = typeof label === "string" && label ? label : "Unknown";
-    return { text, colorVar: "" };
+    return { text, variant: "neutral" };
   }
-  return { text: cfg.display, colorVar: cfg.colorVar };
+  return {
+    text: cfg.display,
+    variant: slug ?? "neutral",
+  };
 }
 
 /**
  * Derive a badge configuration for a sauce type label.
  *
- * Returns a stable `text` and `colorVar` for use with `<Badge />`.
+ * Returns a stable `text` and `variant` for use with `<Badge />`.
  * Falls back to a neutral display when the label cannot be mapped.
  *
  * Examples:
- * - getTypeBadge("Pizza Sauce") -> { text: "Pizza Sauce", colorVar: "--color-brand-yellow" }
- * - getTypeBadge(123) -> { text: "Unknown", colorVar: "" }
+ * - getTypeBadge("Pizza Sauce") -> { text: "Pizza Sauce", variant: "pizza" }
+ * - getTypeBadge(123) -> { text: "Unknown", variant: "neutral" }
  */
 export function getTypeBadge(label: unknown): BadgeConfig {
   const slug = toTypeSlug(label);
   const cfg = slug ? typeMap[slug] : undefined;
   if (!cfg) {
     const text = typeof label === "string" && label ? label : "Unknown";
-    return { text, colorVar: "" };
+    return { text, variant: "neutral" };
   }
-  return { text: cfg.display, colorVar: cfg.colorVar };
+  return {
+    text: cfg.display,
+    variant: slug ?? "neutral",
+  };
 }
 
 /**

--- a/apps/web/src/config/sauce-taxonomy.ts
+++ b/apps/web/src/config/sauce-taxonomy.ts
@@ -1,5 +1,6 @@
 // Taxonomy config and helpers for Sauces Index
 // Mapping canonical slugs to Sanity labels, display labels, and badge colors
+import { stegaClean } from "next-sanity";
 
 export type LineSlug = "original" | "organic" | "premium";
 export type TypeSlug = "pasta" | "pizza" | "salsa" | "sandwich";
@@ -28,6 +29,13 @@ interface TypeConfigItem {
   readonly colorVar: string;
 }
 
+/**
+ * Canonical product line configuration keyed by slug.
+ *
+ * Used to:
+ * - Render badge colors/labels in UI
+ * - Convert between slugs and human-readable labels
+ */
 export const lineMap: Record<LineSlug, LineConfigItem> = {
   original: {
     label: "Original",
@@ -46,6 +54,13 @@ export const lineMap: Record<LineSlug, LineConfigItem> = {
   },
 } as const;
 
+/**
+ * Canonical sauce type configuration keyed by slug.
+ *
+ * Used to:
+ * - Render badge colors/labels in UI
+ * - Convert between slugs and human-readable labels
+ */
 export const typeMap: Record<TypeSlug, TypeConfigItem> = {
   pasta: {
     label: "Pasta Sauce",
@@ -69,12 +84,18 @@ export const typeMap: Record<TypeSlug, TypeConfigItem> = {
   },
 } as const;
 
+/**
+ * Inverse lookup: human-readable line label -> canonical slug.
+ */
 const inverseLine: Record<LineLabel, LineSlug> = {
   Original: "original",
   Organic: "organic",
   "Ultra-Premium": "premium",
 } as const;
 
+/**
+ * Inverse lookup: human-readable type label -> canonical slug.
+ */
 const inverseType: Record<TypeLabel, TypeSlug> = {
   "Pasta Sauce": "pasta",
   "Pizza Sauce": "pizza",
@@ -82,24 +103,86 @@ const inverseType: Record<TypeLabel, TypeSlug> = {
   "Sandwich Sauce": "sandwich",
 } as const;
 
+/**
+ * Convert a human-readable product line label from Sanity into a canonical line slug.
+ *
+ * Why: UI components (e.g., Badge variants, filters) key off stable slugs
+ * such as "original"/"organic"/"premium" rather than the display labels.
+ *
+ * Note: Strings coming from the Sanity Live Content API may contain hidden
+ * steganographic metadata for live preview features. We call `stegaClean` to
+ * strip that metadata so exact map lookups work as expected.
+ *
+ * Examples:
+ * - toLineSlug("Original") -> "original"
+ * - toLineSlug("Organic") -> "organic"
+ * - toLineSlug("Ultra-Premium") -> "premium"
+ */
 export function toLineSlug(label: unknown): LineSlug | undefined {
   if (!label) return undefined;
-  return inverseLine[label as LineLabel];
+  // Sanity Live Content API embeds invisible stega metadata in strings.
+  // Clean it to ensure exact key matches against our inverse map.
+  const clean = stegaClean(String(label));
+  return inverseLine[clean as LineLabel];
 }
 
+/**
+ * Convert a human-readable sauce type label from Sanity into a canonical type slug.
+ *
+ * Why: Filtering, sorting, and visual variants expect type slugs like
+ * "pasta"/"pizza"/"salsa"/"sandwich".
+ *
+ * Also strips any Live Preview stega metadata to ensure map lookups succeed.
+ *
+ * Examples:
+ * - toTypeSlug("Pasta Sauce") -> "pasta"
+ * - toTypeSlug("Pizza Sauce") -> "pizza"
+ * - toTypeSlug("Salsa Sauce") -> "salsa"
+ */
 export function toTypeSlug(label: unknown): TypeSlug | undefined {
   if (!label) return undefined;
-  return inverseType[label as TypeLabel];
+  const clean = stegaClean(String(label));
+  return inverseType[clean as TypeLabel];
 }
 
+/**
+ * Convert a canonical line slug back to its human-readable label.
+ *
+ * Used when hydrating canonical data back into UI-facing shapes
+ * (see `hydrateFromCanonical` in `lib/sauces/filters.ts`).
+ *
+ * Examples:
+ * - fromLineSlug("original") -> "Original"
+ * - fromLineSlug("organic") -> "Organic"
+ */
 export function fromLineSlug(slug: LineSlug): LineLabel {
   return lineMap[slug].label;
 }
 
+/**
+ * Convert a canonical type slug back to its human-readable label.
+ *
+ * Used when transforming canonical internal values into display strings
+ * for UI components and content.
+ *
+ * Examples:
+ * - fromTypeSlug("pizza") -> "Pizza Sauce"
+ * - fromTypeSlug("sandwich") -> "Sandwich Sauce"
+ */
 export function fromTypeSlug(slug: TypeSlug): TypeLabel {
   return typeMap[slug].label;
 }
 
+/**
+ * Derive a badge configuration for a product line label.
+ *
+ * Returns a stable `text` and `colorVar` used by the shared `<Badge />`
+ * component. Falls back to a neutral badge when the label is unknown.
+ *
+ * Examples:
+ * - getLineBadge("Organic") -> { text: "Organic", colorVar: "--color-th-green-500" }
+ * - getLineBadge("Unknown Line") -> { text: "Unknown Line", colorVar: "" }
+ */
 export function getLineBadge(label: unknown): BadgeConfig {
   const slug = toLineSlug(label);
   const cfg = slug ? lineMap[slug] : undefined;
@@ -110,6 +193,16 @@ export function getLineBadge(label: unknown): BadgeConfig {
   return { text: cfg.display, colorVar: cfg.colorVar };
 }
 
+/**
+ * Derive a badge configuration for a sauce type label.
+ *
+ * Returns a stable `text` and `colorVar` for use with `<Badge />`.
+ * Falls back to a neutral display when the label cannot be mapped.
+ *
+ * Examples:
+ * - getTypeBadge("Pizza Sauce") -> { text: "Pizza Sauce", colorVar: "--color-brand-yellow" }
+ * - getTypeBadge(123) -> { text: "Unknown", colorVar: "" }
+ */
 export function getTypeBadge(label: unknown): BadgeConfig {
   const slug = toTypeSlug(label);
   const cfg = slug ? typeMap[slug] : undefined;
@@ -120,5 +213,14 @@ export function getTypeBadge(label: unknown): BadgeConfig {
   return { text: cfg.display, colorVar: cfg.colorVar };
 }
 
+/**
+ * Enumerates all valid product line slugs.
+ * Useful for filters, checkboxes, or generating UI menus.
+ */
 export const allLineSlugs: LineSlug[] = ["original", "organic", "premium"];
+
+/**
+ * Enumerates all valid sauce type slugs.
+ * Useful for type filters, tabs, and validation.
+ */
 export const allTypeSlugs: TypeSlug[] = ["pasta", "pizza", "salsa", "sandwich"];

--- a/apps/web/src/config/sauce-taxonomy.ts
+++ b/apps/web/src/config/sauce-taxonomy.ts
@@ -1,0 +1,114 @@
+// Taxonomy config and helpers for Sauces Index
+// Mapping canonical slugs to Sanity labels, display labels, and badge colors
+
+export type LineSlug = "original" | "organic" | "premium";
+export type TypeSlug = "pasta" | "pizza" | "salsa" | "sandwich";
+
+export type LineLabel = "Original" | "Organic" | "Ultra-Premium";
+export type TypeLabel =
+  | "Pasta Sauce"
+  | "Pizza Sauce"
+  | "Salsa Sauce"
+  | "Sandwich Sauce";
+
+export interface BadgeConfig {
+  readonly text: string;
+  readonly colorVar: string; // CSS variable name, e.g. --color-th-green-500
+}
+
+interface LineConfigItem {
+  readonly label: LineLabel;
+  readonly display: string;
+  readonly colorVar: string;
+}
+
+interface TypeConfigItem {
+  readonly label: TypeLabel;
+  readonly display: string;
+  readonly colorVar: string;
+}
+
+export const lineMap: Record<LineSlug, LineConfigItem> = {
+  original: {
+    label: "Original",
+    display: "Original",
+    colorVar: "--color-th-red-600",
+  },
+  organic: {
+    label: "Organic",
+    display: "Organic",
+    colorVar: "--color-th-green-500",
+  },
+  premium: {
+    label: "Ultra-Premium",
+    display: "Premium",
+    colorVar: "--color-th-dark-900",
+  },
+} as const;
+
+export const typeMap: Record<TypeSlug, TypeConfigItem> = {
+  pasta: {
+    label: "Pasta Sauce",
+    display: "Pasta Sauce",
+    colorVar: "--color-brand-red",
+  },
+  pizza: {
+    label: "Pizza Sauce",
+    display: "Pizza Sauce",
+    colorVar: "--color-brand-yellow",
+  },
+  salsa: {
+    label: "Salsa Sauce",
+    display: "Salsa Sauce",
+    colorVar: "--color-brand-green",
+  },
+  sandwich: {
+    label: "Sandwich Sauce",
+    display: "Sandwich Sauce",
+    colorVar: "",
+  },
+} as const;
+
+const inverseLine: Record<LineLabel, LineSlug> = {
+  Original: "original",
+  Organic: "organic",
+  "Ultra-Premium": "premium",
+} as const;
+
+const inverseType: Record<TypeLabel, TypeSlug> = {
+  "Pasta Sauce": "pasta",
+  "Pizza Sauce": "pizza",
+  "Salsa Sauce": "salsa",
+  "Sandwich Sauce": "sandwich",
+} as const;
+
+export function toLineSlug(label: LineLabel): LineSlug {
+  return inverseLine[label];
+}
+
+export function toTypeSlug(label: TypeLabel): TypeSlug {
+  return inverseType[label];
+}
+
+export function fromLineSlug(slug: LineSlug): LineLabel {
+  return lineMap[slug].label;
+}
+
+export function fromTypeSlug(slug: TypeSlug): TypeLabel {
+  return typeMap[slug].label;
+}
+
+export function getLineBadge(label: LineLabel): BadgeConfig {
+  const slug = toLineSlug(label);
+  const cfg = lineMap[slug];
+  return { text: cfg.display, colorVar: cfg.colorVar };
+}
+
+export function getTypeBadge(label: TypeLabel): BadgeConfig {
+  const slug = toTypeSlug(label);
+  const cfg = typeMap[slug];
+  return { text: cfg.display, colorVar: cfg.colorVar };
+}
+
+export const allLineSlugs: LineSlug[] = ["original", "organic", "premium"];
+export const allTypeSlugs: TypeSlug[] = ["pasta", "pizza", "salsa", "sandwich"];

--- a/apps/web/src/config/sauce-taxonomy.ts
+++ b/apps/web/src/config/sauce-taxonomy.ts
@@ -82,12 +82,14 @@ const inverseType: Record<TypeLabel, TypeSlug> = {
   "Sandwich Sauce": "sandwich",
 } as const;
 
-export function toLineSlug(label: LineLabel): LineSlug {
-  return inverseLine[label];
+export function toLineSlug(label: unknown): LineSlug | undefined {
+  if (!label) return undefined;
+  return inverseLine[label as LineLabel];
 }
 
-export function toTypeSlug(label: TypeLabel): TypeSlug {
-  return inverseType[label];
+export function toTypeSlug(label: unknown): TypeSlug | undefined {
+  if (!label) return undefined;
+  return inverseType[label as TypeLabel];
 }
 
 export function fromLineSlug(slug: LineSlug): LineLabel {
@@ -98,15 +100,23 @@ export function fromTypeSlug(slug: TypeSlug): TypeLabel {
   return typeMap[slug].label;
 }
 
-export function getLineBadge(label: LineLabel): BadgeConfig {
+export function getLineBadge(label: unknown): BadgeConfig {
   const slug = toLineSlug(label);
-  const cfg = lineMap[slug];
+  const cfg = slug ? lineMap[slug] : undefined;
+  if (!cfg) {
+    const text = typeof label === "string" && label ? label : "Unknown";
+    return { text, colorVar: "" };
+  }
   return { text: cfg.display, colorVar: cfg.colorVar };
 }
 
-export function getTypeBadge(label: TypeLabel): BadgeConfig {
+export function getTypeBadge(label: unknown): BadgeConfig {
   const slug = toTypeSlug(label);
-  const cfg = typeMap[slug];
+  const cfg = slug ? typeMap[slug] : undefined;
+  if (!cfg) {
+    const text = typeof label === "string" && label ? label : "Unknown";
+    return { text, colorVar: "" };
+  }
   return { text: cfg.display, colorVar: cfg.colorVar };
 }
 

--- a/apps/web/src/lib/sanity/query.ts
+++ b/apps/web/src/lib/sanity/query.ts
@@ -396,3 +396,32 @@ export const querySettingsData = defineQuery(`
     "contactEmail": contactEmail,
   }
 `);
+
+// Sauces index queries
+export const getSauceIndexPageQuery = defineQuery(`
+  *[_type == "sauceIndex"][0]{
+    _id,
+    _type,
+    title,
+    description,
+    "slug": slug.current
+  }
+`);
+
+export const getAllSaucesForIndexQuery = defineQuery(`
+  *[_type == "sauce" && !(_id in path('drafts.**'))] | order(name asc){
+    _id,
+    name,
+    "slug": slug.current,
+    line,
+    category,
+    "descriptionPlain": pt::text(description),
+    "mainImage": {
+      "id": coalesce(mainImage.asset._ref, ""),
+      "preview": mainImage.asset->metadata.lqip,
+      "hotspot": mainImage.hotspot{ x, y },
+      "crop": mainImage.crop{ top, bottom, left, right },
+      "alt": mainImage.alt
+    }
+  }
+`);

--- a/apps/web/src/lib/sanity/sanity.types.ts
+++ b/apps/web/src/lib/sanity/sanity.types.ts
@@ -3152,6 +3152,40 @@ export type QuerySettingsDataResult = {
   } | null;
   contactEmail: string | null;
 } | null;
+// Variable: getSauceIndexPageQuery
+// Query: *[_type == "sauceIndex"][0]{    _id,    _type,    title,    description,    "slug": slug.current  }
+export type GetSauceIndexPageQueryResult = {
+  _id: string;
+  _type: "sauceIndex";
+  title: string | null;
+  description: string | null;
+  slug: string;
+} | null;
+// Variable: getAllSaucesForIndexQuery
+// Query: *[_type == "sauce" && !(_id in path('drafts.**'))] | order(name asc){    _id,    name,    "slug": slug.current,    line,    category,    "descriptionPlain": pt::text(description),    "mainImage": {      "id": coalesce(mainImage.asset._ref, ""),      "preview": mainImage.asset->metadata.lqip,      "hotspot": mainImage.hotspot{ x, y },      "crop": mainImage.crop{ top, bottom, left, right },      "alt": mainImage.alt    }  }
+export type GetAllSaucesForIndexQueryResult = Array<{
+  _id: string;
+  name: string;
+  slug: string;
+  line: "Organic" | "Original" | "Ultra-Premium";
+  category: "Pasta Sauce" | "Pizza Sauce" | "Salsa Sauce" | "Sandwich Sauce";
+  descriptionPlain: string;
+  mainImage: {
+    id: string | "";
+    preview: string | null;
+    hotspot: {
+      x: number;
+      y: number;
+    } | null;
+    crop: {
+      top: number;
+      bottom: number;
+      left: number;
+      right: number;
+    } | null;
+    alt: string | null;
+  };
+}>;
 
 // Query TypeMap
 import "@sanity/client";
@@ -3173,5 +3207,7 @@ declare module "@sanity/client" {
     '{\n  "slugPages": *[_type == "page" && defined(slug.current)]{\n    "slug": slug.current,\n    "lastModified": _updatedAt\n  },\n  "blogPages": *[_type == "blog" && defined(slug.current)]{\n    "slug": slug.current,\n    "lastModified": _updatedAt\n  }\n}': QuerySitemapDataResult;
     '\n  *[_type == "settings"][0]{\n    _id,\n    _type,\n    siteTitle,\n    siteDescription,\n    addressLines,\n    contactEmail,\n    tollFreePhone,\n    officePhone,\n    socialLinks{\n      linkedin,\n      facebook,\n      twitter,\n      instagram,\n      youtube\n    }\n  }\n': QueryGlobalSeoSettingsResult;
     '\n  *[_type == "settings"][0]{\n    _id,\n    _type,\n    siteTitle,\n    siteDescription,\n    "socialLinks": socialLinks,\n    "contactEmail": contactEmail,\n  }\n': QuerySettingsDataResult;
+    '\n  *[_type == "sauceIndex"][0]{\n    _id,\n    _type,\n    title,\n    description,\n    "slug": slug.current\n  }\n': GetSauceIndexPageQueryResult;
+    '\n  *[_type == "sauce" && !(_id in path(\'drafts.**\'))] | order(name asc){\n    _id,\n    name,\n    "slug": slug.current,\n    line,\n    category,\n    "descriptionPlain": pt::text(description),\n    "mainImage": {\n      "id": coalesce(mainImage.asset._ref, ""),\n      "preview": mainImage.asset->metadata.lqip,\n      "hotspot": mainImage.hotspot{ x, y },\n      "crop": mainImage.crop{ top, bottom, left, right },\n      "alt": mainImage.alt\n    }\n  }\n': GetAllSaucesForIndexQueryResult;
   }
 }

--- a/apps/web/src/lib/sauces/filters.ts
+++ b/apps/web/src/lib/sauces/filters.ts
@@ -64,7 +64,10 @@ export function filterByProductLine(
 ): SauceListItem[] {
   if (!lines?.length) return items;
   const set = new Set<LineSlug>(lines);
-  return items.filter((it) => set.has(toLineSlug(it.line)));
+  return items.filter((it) => {
+    const slug = toLineSlug(it.line);
+    return slug ? set.has(slug) : false;
+  });
 }
 
 export function filterBySauceType(
@@ -72,7 +75,10 @@ export function filterBySauceType(
   type: TypeSlug | "all",
 ): SauceListItem[] {
   if (!type || type === "all") return items;
-  return items.filter((it) => toTypeSlug(it.category) === type);
+  return items.filter((it) => {
+    const slug = toTypeSlug(it.category);
+    return slug === type;
+  });
 }
 
 export function applyFiltersAndSort(

--- a/apps/web/src/lib/sauces/filters.ts
+++ b/apps/web/src/lib/sauces/filters.ts
@@ -1,0 +1,95 @@
+import {
+  fromLineSlug,
+  fromTypeSlug,
+  type LineSlug,
+  toLineSlug,
+  toTypeSlug,
+  type TypeSlug,
+} from "@/config/sauce-taxonomy";
+import type { SauceListItem, SortOrder } from "@/types";
+
+import type { SauceQueryState } from "./url";
+
+function normalize(value: unknown): string {
+  return String(value ?? "")
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "");
+}
+
+function isSubsequence(needle: string, haystack: string): boolean {
+  if (!needle) return true;
+  let i = 0;
+  for (let j = 0; j < haystack.length && i < needle.length; j++) {
+    if (needle[i] === haystack[j]) i++;
+  }
+  return i === needle.length;
+}
+
+function fuzzyMatch(query: string, text: string): boolean {
+  const q = normalize(query).trim();
+  if (!q) return true;
+  const t = normalize(text);
+  // Simple contains or subsequence match as a lightweight fuzzy
+  return t.includes(q) || isSubsequence(q, t);
+}
+
+export function sortByName(
+  items: SauceListItem[],
+  order: SortOrder = "az",
+): SauceListItem[] {
+  const cmp = (a: SauceListItem, b: SauceListItem) =>
+    a.name.localeCompare(b.name, "en-US", { sensitivity: "base" });
+  const sorted = [...items].sort(cmp);
+  return order === "za" ? sorted.reverse() : sorted;
+}
+
+export function filterBySearch(
+  items: SauceListItem[],
+  search: string,
+): SauceListItem[] {
+  if (!search?.trim()) return items;
+  return items.filter((it) =>
+    fuzzyMatch(search, `${it.name} ${it.descriptionPlain ?? ""}`),
+  );
+}
+
+export function filterByProductLine(
+  items: SauceListItem[],
+  lines: LineSlug[],
+): SauceListItem[] {
+  if (!lines?.length) return items;
+  const set = new Set<LineSlug>(lines);
+  return items.filter((it) => set.has(toLineSlug(it.line)));
+}
+
+export function filterBySauceType(
+  items: SauceListItem[],
+  type: TypeSlug | "all",
+): SauceListItem[] {
+  if (!type || type === "all") return items;
+  return items.filter((it) => toTypeSlug(it.category) === type);
+}
+
+export function applyFiltersAndSort(
+  items: SauceListItem[],
+  state: SauceQueryState,
+): SauceListItem[] {
+  const afterSearch = filterBySearch(items, state.search);
+  const afterLine = filterByProductLine(afterSearch, state.productLine);
+  const afterType = filterBySauceType(afterLine, state.sauceType);
+  return sortByName(afterType, state.sort);
+}
+
+export function hydrateFromCanonical(
+  item: Omit<SauceListItem, "line" | "category"> & {
+    line: LineSlug;
+    category: TypeSlug;
+  },
+): SauceListItem {
+  return {
+    ...item,
+    line: fromLineSlug(item.line),
+    category: fromTypeSlug(item.category),
+  };
+}

--- a/apps/web/src/lib/sauces/url.ts
+++ b/apps/web/src/lib/sauces/url.ts
@@ -1,0 +1,74 @@
+import {
+  allLineSlugs,
+  allTypeSlugs,
+  type LineSlug,
+  type TypeSlug,
+} from "@/config/sauce-taxonomy";
+import type { SortOrder } from "@/types";
+
+export interface SauceQueryState {
+  readonly search: string;
+  readonly productLine: LineSlug[]; // canonical slugs
+  readonly sauceType: TypeSlug | "all";
+  readonly sort: SortOrder; // az | za
+}
+
+export type SearchParamsLike = Record<string, string | string[] | undefined>;
+
+const DEFAULT_STATE: SauceQueryState = {
+  search: "",
+  productLine: [],
+  sauceType: "all",
+  sort: "az",
+} as const;
+
+function toArray(value: string | string[] | undefined): string[] {
+  if (!value) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+export function parseSearchParams(
+  params: SearchParamsLike = {},
+): SauceQueryState {
+  const search = typeof params.search === "string" ? params.search : "";
+
+  const productLineRaw = toArray(params.productLine);
+  const productLine = productLineRaw.filter((v): v is LineSlug =>
+    (allLineSlugs as readonly string[]).includes(v),
+  ) as LineSlug[];
+
+  const sauceTypeRaw =
+    typeof params.sauceType === "string" ? params.sauceType : undefined;
+  const sauceType: SauceQueryState["sauceType"] =
+    sauceTypeRaw && (allTypeSlugs as readonly string[]).includes(sauceTypeRaw)
+      ? (sauceTypeRaw as TypeSlug)
+      : sauceTypeRaw === "all" || !sauceTypeRaw
+        ? "all"
+        : "all";
+
+  const sortRaw = typeof params.sort === "string" ? params.sort : undefined;
+  const sort: SortOrder = sortRaw === "za" ? "za" : "az";
+
+  return {
+    search,
+    productLine,
+    sauceType,
+    sort,
+  };
+}
+
+export function serializeStateToParams(
+  state: SauceQueryState,
+): URLSearchParams {
+  const sp = new URLSearchParams();
+  const { search, productLine, sauceType, sort } = state;
+
+  if (search?.trim()) sp.set("search", search.trim());
+  for (const line of productLine) sp.append("productLine", line);
+  if (sauceType && sauceType !== "all") sp.set("sauceType", sauceType);
+  if (sort && sort !== "az") sp.set("sort", sort);
+
+  return sp;
+}
+
+export { DEFAULT_STATE };

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -1,5 +1,6 @@
-import type { LineLabel, TypeLabel } from "@/config/sauce-taxonomy";
 import type {
+  GetAllSaucesForIndexQueryResult,
+  GetSauceIndexPageQueryResult,
   QueryBlogSlugPageDataResult,
   QueryHomePageDataResult,
   QueryImageTypeResult,
@@ -30,27 +31,8 @@ export type SanityRichTextBlock = Extract<
 
 export type Maybe<T> = T | null | undefined;
 
-// Sauces index types
-export interface SauceIndexPageData {
-  readonly _id: string;
-  readonly _type: string;
-  readonly title?: string | null;
-  readonly description?: string | null;
-  readonly slug?: string | null;
-}
-
-export interface SauceCardImage extends SanityImageProps {
-  readonly alt?: string | null;
-}
-
-export interface SauceListItem {
-  readonly _id: string;
-  readonly name: string;
-  readonly slug: string;
-  readonly line: LineLabel;
-  readonly category: TypeLabel;
-  readonly descriptionPlain?: string | null;
-  readonly mainImage?: SauceCardImage | null;
-}
+// Sauces index types derived from generated query result types (tight coupling)
+export type SauceIndexPageData = NonNullable<GetSauceIndexPageQueryResult>;
+export type SauceListItem = GetAllSaucesForIndexQueryResult[number];
 
 export type SortOrder = "az" | "za";

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -1,3 +1,4 @@
+import type { LineLabel, TypeLabel } from "@/config/sauce-taxonomy";
 import type {
   QueryBlogSlugPageDataResult,
   QueryHomePageDataResult,
@@ -28,3 +29,28 @@ export type SanityRichTextBlock = Extract<
 >;
 
 export type Maybe<T> = T | null | undefined;
+
+// Sauces index types
+export interface SauceIndexPageData {
+  readonly _id: string;
+  readonly _type: string;
+  readonly title?: string | null;
+  readonly description?: string | null;
+  readonly slug?: string | null;
+}
+
+export interface SauceCardImage extends SanityImageProps {
+  readonly alt?: string | null;
+}
+
+export interface SauceListItem {
+  readonly _id: string;
+  readonly name: string;
+  readonly slug: string;
+  readonly line: LineLabel;
+  readonly category: TypeLabel;
+  readonly descriptionPlain?: string | null;
+  readonly mainImage?: SauceCardImage | null;
+}
+
+export type SortOrder = "az" | "za";

--- a/context-pack-sauce-index.md
+++ b/context-pack-sauce-index.md
@@ -1,0 +1,409 @@
+You are a coding assistant. Follow the docs below in the given authority order.
+
+AUTHORITY
+
+1. PRD = business constraints (tie-breaker on scope/URLs/data model)
+2. Plan = implementation plan (tie-breaker on code structure/tasks)
+
+WHEN YOU RESPOND
+
+1. Open questions (if any)
+2. Next commit(s): files touched + diffs/code blocks
+3. Test/QA checklist
+
+--- PRD (short) ---
+
+# PRD: Sauces Index Page (/sauces)
+
+## Objective
+
+Build an accessible, SSR-first Sauces Index page that lists all published `sauce` documents from Sanity with client-side filtering, sorting, and deep-linkable state via query params. No pagination for now. Images lazy-load. Fully keyboard-accessible. Mobile uses a filter Sheet.
+
+## Scope
+
+- In scope: SSR data fetch; client filtering (search, product line multi-select, sauce type single-select), sorting (name A→Z/Z→A), URL param sync, responsive layout (sidebar on desktop, sheet on mobile), a11y.
+- Out of scope: backend filtering; Finsweet; featured block; analytics; facet counts (can be added later); pagination.
+
+## Data Model
+
+- Source: Sanity `sauce` docs (published only).
+- Fields used: `name` (string), `slug` (string, required, unique), `line` ("Original" | "Organic" | "Ultra-Premium"), `category` ("Pasta Sauce" | "Pizza Sauce" | "Salsa Sauce" | "Sandwich Sauce"), `description` (richText), `mainImage` (image with `asset._ref`, `metadata.lqip`, `hotspot`, `crop`, `alt`).
+- Page copy/SEO: `sauceIndex` document.
+
+## Routes
+
+- Index: `/sauces` (App Router)
+- Detail: `/sauces/[slug]`
+
+## URL Parameters (Deep-Linkable State)
+
+- `search`: string; fuzzy search across `name` and plain-text description.
+- `productLine`: multi-valued; canonical slugs (e.g., `productLine=original&productLine=organic`).
+- `sauceType`: single-valued; canonical slug (e.g., `sauceType=pasta`); `all` or omitted == no filter.
+- `sort`: `az` (default) | `za`.
+
+Canonical value slugs (config-driven):
+
+- Lines: `original`, `organic`, `premium` (maps to Sanity `Ultra-Premium`).
+- Types: `pasta`, `pizza`, `salsa`, `sandwich`.
+
+## Label Translations and Colors (Config)
+
+Create `apps/web/src/config/sauce-taxonomy.ts`:
+
+- Mapping between canonical slugs ↔ Sanity labels + display labels.
+  - Lines display labels: Original → "Original"; Organic → "Organic"; Ultra-Premium → "Premium" (confirmed).
+  - Types display labels: full names (e.g., "Pasta Sauce").
+- Badge color tokens (via CSS var classes or styles):
+  - Lines: Organic → `--color-th-green-500`; Original → `--color-th-red-600`; Premium → `--color-th-dark-900`.
+  - Types: Pasta Sauce → `--color-brand-red`; Pizza Sauce → `--color-brand-yellow`; Salsa Sauce → `--color-brand-green`; Sandwich Sauce → neutral.
+- Helpers:
+  - `toLineSlug(label)`, `toTypeSlug(label)`
+  - `fromLineSlug(slug)`, `fromTypeSlug(slug)`
+  - `getLineBadge(label)` / `getTypeBadge(label)` → `{ text: string, colorVar: string }`
+
+## Data Fetching (SSR + Live)
+
+- Queries in `apps/web/src/lib/sanity/query.ts`:
+  - `getSauceIndexPageQuery`: fetch `sauceIndex` doc (title, description, SEO fields).
+  - `getAllSaucesForIndexQuery`: fetch all published sauces ordered by `name asc` with projection:
+    - `_id`, `name`, `"slug": slug.current`, `line`, `category`,
+    - `"descriptionPlain": pt::text(description)`,
+    - `mainImage{ "id": asset._ref, "preview": asset->metadata.lqip, hotspot, crop, alt }`.
+- Live (preview): wrap list area in next-sanity LiveQuery boundary when draft/preview is enabled using same query + params.
+- Production: plain SSR; no revalidate needed (live queries handle freshness in preview; production relies on SSR on request or ISR as globally configured if any).
+
+## Server-Side Behavior
+
+- Parse `searchParams` in the server page and compute initial filtered+sorted list (using same pure functions as client) to avoid hydration flash. Still fetch the full dataset on the server. Hydration picks up with identical state.
+
+## Client Filtering & Sorting
+
+- Base array: SSR dataset.
+- Search: fuzzy across `name` and `descriptionPlain`. Use Fuse.js with keys `["name", "descriptionPlain"]`, threshold ~0.3, case-insensitive; debounce input 200ms.
+- Product Line: multi-select inclusion based on line slug.
+- Sauce Type: single-select equality; `all` disables the filter.
+- Sort: by `name` using `localeCompare('en-US', { sensitivity: 'base' })`; `az` ascending, `za` descending.
+- URL syncing: Reflect changes via `router.replace` with updated query params; don’t scroll.
+
+## Layout & Responsiveness
+
+- Desktop (≥lg): two-column layout with left filter sidebar (sticky) and right card grid.
+  - Grid columns: 3 (lg), 2 (md), 1 (sm).
+- Mobile (<lg): hide sidebar; show a "Filters" button that opens `Sheet` from `@workspace/ui`. The sheet contains the same filters and an "Apply" button that commits changes (URL + state) and closes the sheet.
+
+## Components
+
+- Page: `apps/web/src/app/sauces/page.tsx` (server component)
+  - Fetch `sauceIndex` and all sauces; parse `searchParams`; compute initial filtered list; render header + pass data and initial state into client component.
+- Client: `apps/web/src/components/sauces/sauces-client.tsx`
+  - Renders: top bar (filters button on mobile, results count, sort dropdown), sidebar or sheet filters, and the grid.
+  - Manages: state, URL syncing, fuzzy search, filtering, sorting, a11y announcements.
+- Card: `apps/web/src/components/sauce-card.tsx`
+  - Entire card clickable (`Link` wrapper to `/sauces/[slug]`), `SanityImage` mainImage with LQIP; heading (`h3`) for name; line/type badges using taxonomy config.
+- Reuse from `@workspace/ui`: `Sheet`, `DropdownMenu`, `Badge`, `Button`.
+
+## Filters UI
+
+- Search: labeled input ("Search sauces"); clear button.
+- Product Line: checkbox group (Original, Organic, Premium). Legend/fieldset; each checkbox labeled.
+- Sauce Type: radio group (All, Pasta Sauce, Pizza Sauce, Salsa Sauce, Sandwich Sauce). Legend/fieldset.
+- Actions: per-section "Clear" and global "Clear all".
+
+## Accessibility
+
+- Use semantic `fieldset`/`legend` for filter groups.
+- Native inputs with visible labels; adequate hit targets.
+- Results count uses `aria-live="polite"` to announce changes.
+- Card link has discernible name (e.g., `aria-label="View {name} sauce"`). Visible focus ring.
+- Sheet: labeled header, focus trap, ESC closes, restores focus to trigger button.
+
+## Performance
+
+- SSR initial render with filtered list when params are present.
+- Client filtering is memoized; search debounced (200ms).
+- Images lazy-load via `SanityImage` with LQIP; specify width/height to avoid CLS.
+- Keep deps minimal (Fuse.js for fuzzy only).
+
+## Error & Empty States
+
+- If Sanity fetch fails: render safe fallback (header + empty state), log server error.
+- If 0 matches: show generic message and "Clear all" action.
+
+## Acceptance Criteria
+
+- `/sauces` SSR renders title/description + all sauces by default.
+- URL params control initial SSR filtering; reloading deep links preserves view.
+- Search fuzzy-matches; debounce works; clearing restores list.
+- Product Line multi-select narrows results; Sauce Type single-select filters; Clear and Clear all function.
+- Sorting defaults to A→Z and toggles to Z→A; persists in URL.
+- Mobile filter sheet works; Apply closes sheet and applies filters; focus management correct.
+- A11y: labels, focus, live region; keyboard-only usage verified.
+- Lint, typecheck, build pass.
+
+## Implementation Tasks
+
+1. Queries: add `getSauceIndexPageQuery`, `getAllSaucesForIndexQuery` in `apps/web/src/lib/sanity/query.ts` using existing image fragments style.
+2. Config: create `apps/web/src/config/sauce-taxonomy.ts` with mappings, colors, and helpers.
+3. Page: implement `apps/web/src/app/sauces/page.tsx` (server) to fetch, SSR-apply initial filtering, and render structure.
+4. Client: implement `apps/web/src/components/sauces/sauces-client.tsx` with URL syncing and a11y.
+5. Card: add `apps/web/src/components/sauce-card.tsx` using `SanityImage` + badges.
+6. Wire UI: use `@workspace/ui` `Sheet`, `DropdownMenu`, `Badge`, `Button`.
+7. QA: run `pnpm -C apps/web lint:fix && pnpm -C apps/web typecheck && pnpm -C apps/web build`.
+
+--- PLAN ---
+
+<?xml version="1.0" encoding="UTF-8"?>
+<plan id="sauces-index" version="1.0" status="pending" created="2025-09-15">
+  <summary>
+    <title>Sauces Index Page (/sauces)</title>
+    <objective>
+      Build an accessible, SSR-first Sauces Index that lists all published sauce documents from Sanity with client-side filtering, sorting, and deep-linkable URL state. No pagination initially. Images lazy-load. Full keyboard accessibility. Mobile uses a filter Sheet.
+    </objective>
+    <scope>
+      <in>
+        <item>SSR data fetch</item>
+        <item>Client filtering: search, product line multi-select, sauce type single-select</item>
+        <item>Sorting: name az/za</item>
+        <item>URL param sync (deep-linkable state)</item>
+        <item>Responsive layout: desktop sidebar, mobile Sheet</item>
+        <item>Accessibility</item>
+      </in>
+      <out>
+        <item>Backend filtering</item>
+        <item>Finsweet</item>
+        <item>Featured block</item>
+        <item>Analytics</item>
+        <item>Facet counts</item>
+        <item>Pagination</item>
+      </out>
+    </scope>
+  </summary>
+
+  <assumptions>
+    <item>Sanity types exist for sauce and sauceIndex; slugs for sauce use /sauces/... prefix.</item>
+    <item>next-sanity defineLive is configured; use sanityFetch pattern.</item>
+    <item>@workspace/ui provides Button, Badge, DropdownMenu, Sheet with Tailwind v4 tokens.</item>
+    <item>App is light-only; no dark variants or theme toggles.</item>
+  </assumptions>
+
+  <deliverables>
+    <item>Route /sauces with SSR initial filtering and consistent hydration.</item>
+    <item>Sanity queries for sauceIndex meta and full sauce list projection.</item>
+    <item>Client filters, sorting, URL syncing, and a11y live updates.</item>
+    <item>Card UI using SanityImage with LQIP and taxonomy badges.</item>
+    <item>XML plan with progress tracking (this document).</item>
+  </deliverables>
+
+  <dependencies>
+    <runtime>
+      <dep name="fuse.js" workspace="apps/web" purpose="fuzzy search" required="true" />
+      <dep name="@workspace/ui" purpose="UI primitives (Button, Badge, DropdownMenu, Sheet)" required="true" />
+    </runtime>
+    <env>
+      <var>NODE_ENV</var>
+      <var>NEXT_PUBLIC_SANITY_PROJECT_ID</var>
+      <var>SANITY_API_READ_TOKEN</var>
+    </env>
+  </dependencies>
+
+  <files>
+    <file path="apps/web/src/lib/sanity/query.ts" role="add-queries" />
+    <file path="apps/web/src/config/sauce-taxonomy.ts" role="taxonomy-config" />
+    <file path="apps/web/src/lib/sauces/filters.ts" role="pure-filter-sort-search" />
+    <file path="apps/web/src/lib/sauces/url.ts" role="parse-serialize-url-state" />
+    <file path="apps/web/src/app/sauces/page.tsx" role="server-route" />
+    <file path="apps/web/src/components/sauces/sauces-client.tsx" role="client-ui-state" />
+    <file path="apps/web/src/components/sauce-card.tsx" role="card" />
+    <file path="apps/web/src/types.ts" role="types-augment" />
+  </files>
+
+  <taxonomy>
+    <line-slugs>
+      <map slug="original" label="Original" display="Original" colorVar="--color-th-red-600" />
+      <map slug="organic" label="Organic" display="Organic" colorVar="--color-th-green-500" />
+      <map slug="premium" label="Ultra-Premium" display="Premium" colorVar="--color-th-dark-900" />
+    </line-slugs>
+    <type-slugs>
+      <map slug="pasta" label="Pasta Sauce" display="Pasta Sauce" colorVar="--color-brand-red" />
+      <map slug="pizza" label="Pizza Sauce" display="Pizza Sauce" colorVar="--color-brand-yellow" />
+      <map slug="salsa" label="Salsa Sauce" display="Salsa Sauce" colorVar="--color-brand-green" />
+      <map slug="sandwich" label="Sandwich Sauce" display="Sandwich Sauce" colorVar="" />
+    </type-slugs>
+  </taxonomy>
+
+  <phases>
+    <phase index="0" name="DesignAndPrep" status="pending">
+      <tasks>
+        <task id="0.1" status="pending">Confirm taxonomy canonical slugs and display labels.</task>
+        <task id="0.2" status="pending">Verify color tokens exist in packages/ui/src/styles/globals.css.</task>
+        <task id="0.3" status="pending">Identify reusable SSR/SEO patterns from blog index and SanityImage usage.</task>
+        <task id="0.4" status="pending">Decide on pure utility locations for shared server/client logic.</task>
+      </tasks>
+      <outputs>
+        <output>Validated taxonomy and tokens.</output>
+        <output>Confirmed file layout for utilities and components.</output>
+      </outputs>
+      <done-when>Taxonomy and tokens are confirmed; file layout finalized.</done-when>
+    </phase>
+
+    <phase index="1" name="DataAndConfig" status="pending">
+      <tasks>
+        <task id="1.1" status="pending">Add getSauceIndexPageQuery to query.ts.</task>
+        <task id="1.2" status="pending">Add getAllSaucesForIndexQuery with projection (_id, name, slug, line, category, descriptionPlain, mainImage fields).</task>
+        <task id="1.3" status="pending">Create sauce-taxonomy.ts with mappings, colors, helpers.</task>
+      </tasks>
+      <outputs>
+        <output>Two queries implemented and typed.</output>
+        <output>Taxonomy config module with helpers.</output>
+      </outputs>
+      <done-when>Queries compile and taxonomy helpers export types.</done-when>
+    </phase>
+
+    <phase index="2" name="TypesAndUtilities" status="pending">
+      <tasks>
+        <task id="2.1" status="pending">Augment apps/web/src/types.ts with index response types.</task>
+        <task id="2.2" status="pending">Create filters.ts with pure filter/search/sort functions (Fuse.js threshold ~0.3).</task>
+        <task id="2.3" status="pending">Create url.ts to parse/serialize SauceQueryParams.</task>
+      </tasks>
+      <outputs>
+        <output>Shared pure utilities for server and client.</output>
+      </outputs>
+      <done-when>Utilities unit-tested informally and types validated by typecheck.</done-when>
+    </phase>
+
+    <phase index="3" name="ServerRoute" status="pending">
+      <tasks>
+        <task id="3.1" status="pending">Implement /sauces page.tsx server component.</task>
+        <task id="3.2" status="pending">Fetch sauceIndex and sauces via sanityFetch.</task>
+        <task id="3.3" status="pending">Parse searchParams and compute initial results with shared utilities.</task>
+        <task id="3.4" status="pending">Render header and pass SSR data + initial state to client component.</task>
+        <task id="3.5" status="pending">Add generateMetadata using getSEOMetadata.</task>
+        <task id="3.6" status="pending">Handle error and empty states gracefully.</task>
+      </tasks>
+      <outputs>
+        <output>SSR page that matches URL-driven initial state.</output>
+      </outputs>
+      <done-when>Reload of deep links preserves filtered/sorted results.</done-when>
+    </phase>
+
+    <phase index="4" name="ClientUI" status="pending">
+      <tasks>
+        <task id="4.1" status="pending">Implement sauces-client.tsx with state, debounced search, filters, sorting.</task>
+        <task id="4.2" status="pending">URL syncing via router.replace without scroll.</task>
+        <task id="4.3" status="pending">Desktop: sticky sidebar; Mobile: Sheet with Apply and focus management.</task>
+        <task id="4.4" status="pending">Add aria-live results count and labeled inputs.</task>
+        <task id="4.5" status="pending">Sorting via @workspace/ui DropdownMenu.</task>
+      </tasks>
+      <outputs>
+        <output>Interactive, accessible client UI.</output>
+      </outputs>
+      <done-when>Keyboard-only interactions fully supported; URL reflects state.</done-when>
+    </phase>
+
+    <phase index="5" name="CardComponent" status="pending">
+      <tasks>
+        <task id="5.1" status="pending">Implement sauce-card.tsx with SanityImage, badges, and accessible Link.</task>
+        <task id="5.2" status="pending">Ensure width/height set to avoid CLS; use LQIP preview.</task>
+      </tasks>
+      <outputs>
+        <output>Reusable SauceCard for the grid.</output>
+      </outputs>
+      <done-when>Images lazy-load and focus ring is visible.</done-when>
+    </phase>
+
+    <phase index="6" name="QAAndPolish" status="pending">
+      <tasks>
+        <task id="6.1" status="pending">Run lint, typecheck, and build for apps/web.</task>
+        <task id="6.2" status="pending">Manual QA against acceptance criteria (desktop and mobile).</task>
+        <task id="6.3" status="pending">Create a changeset for web (patch).</task>
+      </tasks>
+      <outputs>
+        <output>Passing quality gates and changeset recorded.</output>
+      </outputs>
+      <done-when>All acceptance criteria are met; build succeeds.</done-when>
+    </phase>
+
+  </phases>
+
+  <acceptance-criteria>
+    <item>/sauces SSR renders title/description and all sauces by default.</item>
+    <item>URL params control initial SSR filtering; refresh preserves the view.</item>
+    <item>Fuzzy search debounced; clear restores list.</item>
+    <item>Product line multi-select; sauce type single-select; per-section Clear and global Clear all.</item>
+    <item>Sorting defaults to az, toggles to za, persists in URL.</item>
+    <item>Mobile Sheet applies filters and manages focus correctly.</item>
+    <item>A11y: fieldset/legend, labeled controls, aria-live updates, focus-visible, ESC closes Sheet.</item>
+    <item>Lint, typecheck, build pass for apps/web.</item>
+  </acceptance-criteria>
+
+  <a11y>
+    <requirement>Use semantic fieldset/legend for filter groups.</requirement>
+    <requirement>Native inputs with visible labels and adequate target size.</requirement>
+    <requirement>aria-live="polite" on results count; announce changes.</requirement>
+    <requirement>Card link with discernible name: aria-label="View {name} sauce".</requirement>
+    <requirement>Sheet has labeled header, focus trap, ESC to close, restores focus to trigger.</requirement>
+  </a11y>
+
+  <performance>
+    <guideline>SSR initial render uses server-side filtered list when params exist.</guideline>
+    <guideline>Memoize client filtering; debounce search by 200ms.</guideline>
+    <guideline>SanityImage uses LQIP and explicit width/height to avoid CLS.</guideline>
+    <guideline>Minimize deps; use Fuse.js only for fuzzy search.</guideline>
+  </performance>
+
+  <risks>
+    <risk id="r1">
+      <desc>Large dataset without pagination may slow SSR and client filtering.</desc>
+      <mitigation>Keep projection minimal; consider server-side filtering or pagination later if needed.</mitigation>
+    </risk>
+    <risk id="r2">
+      <desc>URL state complexity could drift between server and client.</desc>
+      <mitigation>Centralize parse/serialize utilities and reuse on both sides.</mitigation>
+    </risk>
+    <risk id="r3">
+      <desc>Live preview behavior divergence.</desc>
+      <mitigation>Use sanityFetch consistently; keep optional Live boundary isolated.</mitigation>
+    </risk>
+  </risks>
+
+  <commands>
+    <quality-gates>
+      <cmd>pnpm -C apps/web lint:fix</cmd>
+      <cmd>pnpm -C apps/web typecheck</cmd>
+      <cmd>pnpm -C apps/web build</cmd>
+    </quality-gates>
+    <versioning>
+      <cmd>pnpm changeset:add</cmd>
+      <note>Select only web; choose patch; add concise summary.</note>
+    </versioning>
+  </commands>
+
+  <progress>
+    <current phase="0" task="0.0" status="pending" updated="2025-09-15" />
+    <history>
+      <event ts="2025-09-15">Plan created from PRD and saved.</event>
+    </history>
+    <instructions>
+      Update phase and task status attributes (pending|in_progress|completed) as work advances. Keep exactly one in_progress task at a time. Record notable events in &lt;history&gt;.</instructions>
+  </progress>
+
+  <appendix>
+    <routes>
+      <index>/sauces</index>
+      <detail>/sauces/[slug]</detail>
+      <url-params>
+        <param name="search" type="string" />
+        <param name="productLine" type="multi" canonical="original|organic|premium" />
+        <param name="sauceType" type="single" canonical="pasta|pizza|salsa|sandwich" />
+        <param name="sort" type="enum" values="az|za" default="az" />
+      </url-params>
+    </routes>
+    <ui-imports>
+      <import>@workspace/ui/components/button</import>
+      <import>@workspace/ui/components/badge</import>
+      <import>@workspace/ui/components/dropdown-menu</import>
+      <import>@workspace/ui/components/sheet</import>
+    </ui-imports>
+  </appendix>
+</plan>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,9 +4,12 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
   },
   "dependencies": {
+    "@radix-ui/react-checkbox": "^1.1.2",
+    "@radix-ui/react-radio-group": "^1.2.1",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/packages/ui/postcss.config.mjs
+++ b/packages/ui/postcss.config.mjs
@@ -1,6 +1,6 @@
 /** @type {import('postcss-load-config').Config} */
 const config = {
-    plugins: { "@tailwindcss/postcss": {} },
+  plugins: { "@tailwindcss/postcss": {} },
 };
 
 export default config;

--- a/packages/ui/src/components/accordion.tsx
+++ b/packages/ui/src/components/accordion.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import * as React from "react";
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
-import { ChevronDownIcon } from "lucide-react";
-
 import { cn } from "@workspace/ui/lib/utils";
+import { ChevronDownIcon } from "lucide-react";
+import * as React from "react";
 
 function Accordion({
   ...props
@@ -63,4 +62,4 @@ function AccordionContent({
   );
 }
 
-export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };
+export { Accordion, AccordionContent, AccordionItem, AccordionTrigger };

--- a/packages/ui/src/components/badge.tsx
+++ b/packages/ui/src/components/badge.tsx
@@ -1,45 +1,64 @@
-import { Slot } from "@radix-ui/react-slot";
 import { cn } from "@workspace/ui/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
-const badgeVariants = cva(
+// Badge style variants: background, foreground, and border colors via CVA
+export const badgeVariants = cva(
   "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
   {
     variants: {
       variant: {
-        default:
-          "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
-        secondary:
+        // Neutral default for generic usage
+        neutral:
           "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
-        destructive:
-          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20",
-        outline:
-          "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+
+        // Product line variants
+        original:
+          "bg-[var(--color-th-red-600)] text-[var(--color-th-light-100)] border-[var(--color-th-red-600)] [a&]:hover:brightness-95",
+        organic:
+          "bg-[var(--color-th-green-500)] text-[var(--color-th-light-100)] border-[var(--color-th-green-500)] [a&]:hover:brightness-95",
+        premium:
+          "bg-[var(--color-th-dark-900)] text-[var(--color-th-light-100)] border-[var(--color-th-dark-900)] [a&]:hover:brightness-125",
+
+        // Sauce type variants
+        pasta:
+          "bg-[var(--color-brand-red)] text-[var(--color-brand-red-text)] border-[var(--color-brand-red)] [a&]:hover:brightness-95",
+        pizza:
+          "bg-[var(--color-brand-yellow)] text-[var(--color-brand-yellow-text)] border-[var(--color-brand-yellow)] [a&]:hover:brightness-95",
+        salsa:
+          "bg-[var(--color-brand-green)] text-[var(--color-brand-green-text)] border-[var(--color-brand-green)] [a&]:hover:brightness-95",
+        sandwich:
+          "bg-[var(--color-th-light-100)] text-[var(--color-th-dark-900)] border-[var(--color-th-neutral-300)] [a&]:hover:bg-[var(--color-th-light-200)]",
       },
     },
     defaultVariants: {
-      variant: "default",
+      variant: "neutral",
     },
   },
 );
 
-function Badge({
-  className,
-  variant,
-  asChild = false,
-  ...props
-}: React.ComponentProps<"span"> &
-  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot : "span";
+type BadgeBaseProps = {
+  text: string;
+  href?: string;
+  className?: string;
+} & Omit<React.HTMLAttributes<HTMLSpanElement>, "children"> &
+  Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, "children">;
+
+type BadgeProps = BadgeBaseProps & VariantProps<typeof badgeVariants>;
+
+function Badge({ text, href, variant, className, ...rest }: BadgeProps) {
+  const Comp = href ? ("a" as const) : ("span" as const);
 
   return (
     <Comp
       data-slot="badge"
+      href={href}
       className={cn(badgeVariants({ variant }), className)}
-      {...props}
-    />
+      {...(rest as any)}
+    >
+      {text}
+    </Comp>
   );
 }
 
-export { Badge, badgeVariants };
+export { Badge };

--- a/packages/ui/src/components/badge.tsx
+++ b/packages/ui/src/components/badge.tsx
@@ -4,7 +4,8 @@ import * as React from "react";
 
 // Badge style variants: background, foreground, and border colors via CVA
 export const badgeVariants = cva(
-  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  `inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden
+  rounded-xs border px-2 py-1 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 [&>svg]:pointer-events-none [&>svg]:size-3`,
   {
     variants: {
       variant: {

--- a/packages/ui/src/components/badge.tsx
+++ b/packages/ui/src/components/badge.tsx
@@ -38,27 +38,49 @@ export const badgeVariants = cva(
   },
 );
 
-type BadgeBaseProps = {
+type CommonProps = {
   text: string;
-  href?: string;
   className?: string;
-} & Omit<React.HTMLAttributes<HTMLSpanElement>, "children"> &
-  Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, "children">;
+} & VariantProps<typeof badgeVariants>;
 
-type BadgeProps = BadgeBaseProps & VariantProps<typeof badgeVariants>;
+type LinkProps = {
+  href: string;
+} & Omit<
+  React.AnchorHTMLAttributes<HTMLAnchorElement>,
+  "children" | "className" | "href"
+>;
 
-function Badge({ text, href, variant, className, ...rest }: BadgeProps) {
-  const Comp = href ? ("a" as const) : ("span" as const);
+type SpanProps = Omit<
+  React.HTMLAttributes<HTMLSpanElement>,
+  "children" | "className"
+> & { href?: never };
 
+type BadgeProps = CommonProps & (LinkProps | SpanProps);
+
+function Badge(props: BadgeProps) {
+  if ("href" in props) {
+    const { text, href, className, variant, ...anchorProps } = props;
+    return (
+      <a
+        data-slot="badge"
+        href={href}
+        className={cn(badgeVariants({ variant }), className)}
+        {...anchorProps}
+      >
+        {text}
+      </a>
+    );
+  }
+
+  const { text, className, variant, ...spanProps } = props;
   return (
-    <Comp
+    <span
       data-slot="badge"
-      href={href}
       className={cn(badgeVariants({ variant }), className)}
-      {...(rest as any)}
+      {...spanProps}
     >
       {text}
-    </Comp>
+    </span>
   );
 }
 

--- a/packages/ui/src/components/checkbox.tsx
+++ b/packages/ui/src/components/checkbox.tsx
@@ -1,0 +1,35 @@
+"use client";
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { cn } from "@workspace/ui/lib/utils";
+import { Check } from "lucide-react";
+import * as React from "react";
+
+export type CheckboxProps = React.ComponentPropsWithoutRef<
+  typeof CheckboxPrimitive.Root
+>;
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  CheckboxProps
+>(function Checkbox({ className, children, ...props }, ref) {
+  return (
+    <CheckboxPrimitive.Root
+      ref={ref}
+      className={cn(
+        "size-4 shrink-0 rounded-sm border border-input bg-white/70",
+        "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        "data-[state=checked]:bg-[var(--color-brand-green)] data-[state=checked]:border-[var(--color-brand-green)]",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator className="grid place-items-center text-[var(--color-brand-green-text)]">
+        <Check className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+      {children}
+    </CheckboxPrimitive.Root>
+  );
+});
+
+export { Checkbox };

--- a/packages/ui/src/components/drawer.tsx
+++ b/packages/ui/src/components/drawer.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import * as DrawerPrimitive from "@radix-ui/react-dialog";
+import { cn } from "@workspace/ui/lib/utils";
+import { XIcon } from "lucide-react";
+import * as React from "react";
+
+function Drawer({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+  return <DrawerPrimitive.Root data-slot="drawer" {...props} />;
+}
+
+function DrawerTrigger({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+  return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />;
+}
+
+function DrawerClose({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />;
+}
+
+function DrawerPortal({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+  return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />;
+}
+
+function DrawerOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+  return (
+    <DrawerPrimitive.Overlay
+      data-slot="drawer-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DrawerContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+  return (
+    <DrawerPortal>
+      <DrawerOverlay />
+      <DrawerPrimitive.Content
+        data-slot="drawer-content"
+        className={cn(
+          "fixed inset-x-0 bottom-0 z-50 mt-auto flex max-h-[92vh] w-full flex-col overflow-hidden rounded-t-xl border-t bg-th-light-200 shadow-lg",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:slide-in-from-bottom data-[state=closed]:slide-out-to-bottom",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <DrawerPrimitive.Close className="ring-offset-background focus:ring-ring absolute right-4 top-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-offset-2">
+          <XIcon className="size-4" />
+          <span className="sr-only">Close</span>
+        </DrawerPrimitive.Close>
+      </DrawerPrimitive.Content>
+    </DrawerPortal>
+  );
+}
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-header"
+      className={cn("flex flex-col gap-1.5 p-4", className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+  return (
+    <DrawerPrimitive.Title
+      data-slot="drawer-title"
+      className={cn("font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+  return (
+    <DrawerPrimitive.Description
+      data-slot="drawer-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+};

--- a/packages/ui/src/components/eyebrow.tsx
+++ b/packages/ui/src/components/eyebrow.tsx
@@ -1,0 +1,43 @@
+import { cn } from "@workspace/ui/lib/utils";
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+// Eyebrow: minimal, no background. Left border + 1rem padding.
+const eyebrowVariants = cva(
+  "inline-flex items-center text-xs leading-none border-l pl-4", // base
+  {
+    variants: {
+      variant: {
+        onLight:
+          "border-[var(--color-th-neutral-300)] text-[var(--color-th-neutral-550)]",
+        onDark:
+          "border-[var(--color-th-light-100)] text-[var(--color-th-light-100)]",
+      },
+    },
+    defaultVariants: {
+      variant: "onLight",
+    },
+  },
+);
+
+export type EyebrowProps = {
+  text: string;
+  className?: string;
+} & VariantProps<typeof eyebrowVariants> &
+  Omit<React.HTMLAttributes<HTMLSpanElement>, "children">;
+
+export function Eyebrow({ text, variant, className, ...rest }: EyebrowProps) {
+  if (!text || text.trim().length === 0) return null;
+
+  return (
+    <span
+      data-slot="eyebrow"
+      className={cn(eyebrowVariants({ variant }), className)}
+      {...rest}
+    >
+      {text}
+    </span>
+  );
+}
+
+export { eyebrowVariants };

--- a/packages/ui/src/components/navigation-menu.tsx
+++ b/packages/ui/src/components/navigation-menu.tsx
@@ -1,9 +1,8 @@
-import * as React from "react";
 import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu";
+import { cn } from "@workspace/ui/lib/utils";
 import { cva } from "class-variance-authority";
 import { ChevronDownIcon } from "lucide-react";
-
-import { cn } from "@workspace/ui/lib/utils";
+import * as React from "react";
 
 function NavigationMenu({
   className,
@@ -157,12 +156,12 @@ function NavigationMenuIndicator({
 
 export {
   NavigationMenu,
-  NavigationMenuList,
-  NavigationMenuItem,
   NavigationMenuContent,
-  NavigationMenuTrigger,
-  NavigationMenuLink,
   NavigationMenuIndicator,
-  NavigationMenuViewport,
+  NavigationMenuItem,
+  NavigationMenuLink,
+  NavigationMenuList,
+  NavigationMenuTrigger,
   navigationMenuTriggerStyle,
+  NavigationMenuViewport,
 };

--- a/packages/ui/src/components/radio-group.tsx
+++ b/packages/ui/src/components/radio-group.tsx
@@ -1,0 +1,49 @@
+"use client";
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
+import { cn } from "@workspace/ui/lib/utils";
+import * as React from "react";
+
+type RootProps = React.ComponentPropsWithoutRef<
+  typeof RadioGroupPrimitive.Root
+>;
+type ItemProps = React.ComponentPropsWithoutRef<
+  typeof RadioGroupPrimitive.Item
+>;
+
+function RadioGroup({ className, ...props }: RootProps) {
+  return (
+    <RadioGroupPrimitive.Root
+      className={cn("grid gap-2", className)}
+      {...props}
+    />
+  );
+}
+
+const RadioGroupItem = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Item>,
+  ItemProps
+>(function RadioGroupItem({ className, children, ...props }, ref) {
+  return (
+    <RadioGroupPrimitive.Item
+      ref={ref}
+      className={cn(
+        "size-4 rounded-full border border-input bg-white/70",
+        "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        "data-[state=checked]:border-[var(--color-brand-green)]",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator
+        className={cn(
+          "relative grid place-items-center",
+          "after:block after:size-2.5 after:rounded-full after:bg-[var(--color-brand-green)]",
+        )}
+      />
+      {children}
+    </RadioGroupPrimitive.Item>
+  );
+});
+
+export { RadioGroup, RadioGroupItem };

--- a/packages/ui/src/components/sheet.tsx
+++ b/packages/ui/src/components/sheet.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import * as React from "react";
 import * as SheetPrimitive from "@radix-ui/react-dialog";
-import { XIcon } from "lucide-react";
-
 import { cn } from "@workspace/ui/lib/utils";
+import { XIcon } from "lucide-react";
+import * as React from "react";
 
 function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
   return <SheetPrimitive.Root data-slot="sheet" {...props} />;
@@ -129,11 +128,11 @@ function SheetDescription({
 
 export {
   Sheet,
-  SheetTrigger,
   SheetClose,
   SheetContent,
-  SheetHeader,
-  SheetFooter,
-  SheetTitle,
   SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
 };

--- a/packages/ui/src/components/sheet.tsx
+++ b/packages/ui/src/components/sheet.tsx
@@ -57,7 +57,7 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          "bg-th-light-200 data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
           side === "right" &&
             "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
           side === "left" &&

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import { clsx, type ClassValue } from "clsx";
+import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -96,7 +96,7 @@
   --color-brand-yellow: oklch(0.9 0.12 90);
   --color-brand-yellow-text: var(--color-th-dark-900);
   --color-brand-red: oklch(0.57 0.21 25);
-  --color-brand-red-text: var(--color-th-light-900);
+  --color-brand-red-text: var(--color-th-light-100);
 
   --color-brand-green-500: var(--color-brand-green);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,13 +39,13 @@ importers:
     dependencies:
       "@sanity/assist":
         specifier: ^5.0.0
-        version: 5.0.0(@emotion/is-prop-valid@1.2.2)(@sanity/mutator@4.6.0(@types/react@19.1.11))(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(sanity@4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1))(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
+        version: 5.0.0(@emotion/is-prop-valid@1.2.2)(@sanity/mutator@4.6.0(@types/react@19.1.11))(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(sanity@4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1))(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
       "@sanity/icons":
         specifier: ^3.7.4
         version: 3.7.4(react@19.1.1)
       "@sanity/orderable-document-list":
         specifier: ^1.4.0
-        version: 1.4.0(@emotion/is-prop-valid@1.2.2)(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(rxjs@7.8.2)(sanity@4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1))(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
+        version: 1.4.0(@emotion/is-prop-valid@1.2.2)(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(rxjs@7.8.2)(sanity@4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1))(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
       "@sanity/ui":
         specifier: ^3.0.7
         version: 3.0.7(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
@@ -63,16 +63,16 @@ importers:
         version: 19.1.1(react@19.1.1)
       sanity:
         specifier: ^4.6.0
-        version: 4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1)
+        version: 4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1)
       sanity-plugin-asset-source-unsplash:
         specifier: ^4.0.1
-        version: 4.0.1(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(sanity@4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1))(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
+        version: 4.0.1(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(sanity@4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1))(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
       sanity-plugin-icon-picker:
         specifier: ^4.0.0
-        version: 4.0.0(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(sanity@4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1))
+        version: 4.0.0(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(sanity@4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1))
       sanity-plugin-media:
         specifier: ^4.0.0
-        version: 4.0.0(@emotion/is-prop-valid@1.2.2)(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(sanity@4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1))(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
+        version: 4.0.0(@emotion/is-prop-valid@1.2.2)(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(sanity@4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1))(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
       slugify:
         specifier: ^1.6.6
         version: 1.6.6
@@ -236,6 +236,9 @@ importers:
       "@radix-ui/react-accordion":
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.1.7(@types/react@19.1.11))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      "@radix-ui/react-checkbox":
+        specifier: ^1.1.2
+        version: 1.3.3(@types/react-dom@19.1.7(@types/react@19.1.11))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       "@radix-ui/react-dialog":
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.1.7(@types/react@19.1.11))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -245,6 +248,9 @@ importers:
       "@radix-ui/react-navigation-menu":
         specifier: ^1.2.14
         version: 1.2.14(@types/react-dom@19.1.7(@types/react@19.1.11))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      "@radix-ui/react-radio-group":
+        specifier: ^1.2.1
+        version: 1.3.8(@types/react-dom@19.1.7(@types/react@19.1.11))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       "@radix-ui/react-slot":
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.11)(react@19.1.1)
@@ -2938,6 +2944,22 @@ packages:
       "@types/react-dom":
         optional: true
 
+  "@radix-ui/react-checkbox@1.3.3":
+    resolution:
+      {
+        integrity: sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      "@types/react-dom":
+        optional: true
+
   "@radix-ui/react-collapsible@1.1.12":
     resolution:
       {
@@ -3178,6 +3200,22 @@ packages:
     resolution:
       {
         integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      "@types/react-dom":
+        optional: true
+
+  "@radix-ui/react-radio-group@1.3.8":
+    resolution:
+      {
+        integrity: sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==,
       }
     peerDependencies:
       "@types/react": "*"
@@ -14776,9 +14814,9 @@ snapshots:
 
   "@pkgr/core@0.2.7": {}
 
-  "@portabletext/block-tools@3.5.1(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@types/react@19.1.11)":
+  "@portabletext/block-tools@3.5.1(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11))(@types/react@19.1.11)":
     dependencies:
-      "@portabletext/sanity-bridge": 1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1))
+      "@portabletext/sanity-bridge": 1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11))
       "@portabletext/schema": 1.2.0
       "@sanity/types": 4.6.0(@types/react@19.1.11)(debug@4.4.1)
       "@types/react": 19.1.11
@@ -14787,12 +14825,12 @@ snapshots:
     transitivePeerDependencies:
       - "@sanity/schema"
 
-  "@portabletext/editor@2.6.7(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11)))(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rxjs@7.8.2)":
+  "@portabletext/editor@2.6.7(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11)))(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rxjs@7.8.2)":
     dependencies:
-      "@portabletext/block-tools": 3.5.1(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@types/react@19.1.11)
+      "@portabletext/block-tools": 3.5.1(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11))(@types/react@19.1.11)
       "@portabletext/keyboard-shortcuts": 1.1.1
       "@portabletext/patches": 1.1.8
-      "@portabletext/sanity-bridge": 1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1))
+      "@portabletext/sanity-bridge": 1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11))
       "@portabletext/schema": 1.2.0
       "@portabletext/to-html": 3.0.0
       "@sanity/schema": 4.6.0(@types/react@19.1.11)(debug@4.4.1)
@@ -14834,7 +14872,7 @@ snapshots:
       "@portabletext/types": 2.0.15
       react: 19.1.1
 
-  "@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1))":
+  "@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11))":
     dependencies:
       "@portabletext/schema": 1.2.0
       "@sanity/schema": 4.6.0(@types/react@19.1.11)(debug@4.4.1)
@@ -14883,6 +14921,22 @@ snapshots:
   "@radix-ui/react-arrow@1.1.7(@types/react-dom@19.1.7(@types/react@19.1.11))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)":
     dependencies:
       "@radix-ui/react-primitive": 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.11))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      "@types/react": 19.1.11
+      "@types/react-dom": 19.1.7(@types/react@19.1.11)
+
+  "@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.1.7(@types/react@19.1.11))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)":
+    dependencies:
+      "@radix-ui/primitive": 1.1.3
+      "@radix-ui/react-compose-refs": 1.1.2(@types/react@19.1.11)(react@19.1.1)
+      "@radix-ui/react-context": 1.1.2(@types/react@19.1.11)(react@19.1.1)
+      "@radix-ui/react-presence": 1.1.5(@types/react-dom@19.1.7(@types/react@19.1.11))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      "@radix-ui/react-primitive": 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.11))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      "@radix-ui/react-use-controllable-state": 1.2.2(@types/react@19.1.11)(react@19.1.1)
+      "@radix-ui/react-use-previous": 1.1.1(@types/react@19.1.11)(react@19.1.1)
+      "@radix-ui/react-use-size": 1.1.1(@types/react@19.1.11)(react@19.1.1)
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
     optionalDependencies:
@@ -15104,6 +15158,24 @@ snapshots:
       "@types/react": 19.1.11
       "@types/react-dom": 19.1.7(@types/react@19.1.11)
 
+  "@radix-ui/react-radio-group@1.3.8(@types/react-dom@19.1.7(@types/react@19.1.11))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)":
+    dependencies:
+      "@radix-ui/primitive": 1.1.3
+      "@radix-ui/react-compose-refs": 1.1.2(@types/react@19.1.11)(react@19.1.1)
+      "@radix-ui/react-context": 1.1.2(@types/react@19.1.11)(react@19.1.1)
+      "@radix-ui/react-direction": 1.1.1(@types/react@19.1.11)(react@19.1.1)
+      "@radix-ui/react-presence": 1.1.5(@types/react-dom@19.1.7(@types/react@19.1.11))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      "@radix-ui/react-primitive": 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.11))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      "@radix-ui/react-roving-focus": 1.1.11(@types/react-dom@19.1.7(@types/react@19.1.11))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      "@radix-ui/react-use-controllable-state": 1.2.2(@types/react@19.1.11)(react@19.1.1)
+      "@radix-ui/react-use-previous": 1.1.1(@types/react@19.1.11)(react@19.1.1)
+      "@radix-ui/react-use-size": 1.1.1(@types/react@19.1.11)(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      "@types/react": 19.1.11
+      "@types/react-dom": 19.1.7(@types/react@19.1.11)
+
   "@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.1.7(@types/react@19.1.11))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)":
     dependencies:
       "@radix-ui/primitive": 1.1.3
@@ -15284,7 +15356,7 @@ snapshots:
 
   "@sanity/asset-utils@2.3.0": {}
 
-  "@sanity/assist@5.0.0(@emotion/is-prop-valid@1.2.2)(@sanity/mutator@4.6.0(@types/react@19.1.11))(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(sanity@4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1))(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))":
+  "@sanity/assist@5.0.0(@emotion/is-prop-valid@1.2.2)(@sanity/mutator@4.6.0(@types/react@19.1.11))(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(sanity@4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1))(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))":
     dependencies:
       "@sanity/icons": 3.7.4(react@19.1.1)
       "@sanity/incompatible-plugin": 1.0.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -15297,7 +15369,7 @@ snapshots:
       react-fast-compare: 3.2.2
       rxjs: 7.8.2
       rxjs-exhaustmap-with-trailing: 2.1.1(rxjs@7.8.2)
-      sanity: 4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1)
+      sanity: 4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1)
       styled-components: 6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
     transitivePeerDependencies:
       - "@emotion/is-prop-valid"
@@ -15547,7 +15619,7 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
-  "@sanity/insert-menu@2.0.1(@emotion/is-prop-valid@1.2.2)(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1))(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))":
+  "@sanity/insert-menu@2.0.1(@emotion/is-prop-valid@1.2.2)(@sanity/types@4.6.0(@types/react@19.1.11))(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))":
     dependencies:
       "@sanity/icons": 3.7.4(react@19.1.1)
       "@sanity/types": 4.6.0(@types/react@19.1.11)(debug@4.4.1)
@@ -15646,7 +15718,7 @@ snapshots:
     dependencies:
       "@sanity/client": 7.10.0(debug@4.4.1)
       "@sanity/comlink": 3.0.9
-      "@sanity/presentation-comlink": 1.0.28(@sanity/client@7.10.0(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1))
+      "@sanity/presentation-comlink": 1.0.28(@sanity/client@7.10.0)(@sanity/types@4.6.0(@types/react@19.1.11))
       dequal: 2.0.3
       next: 15.5.2(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react: 19.1.1
@@ -15655,7 +15727,7 @@ snapshots:
       - "@sanity/types"
       - debug
 
-  "@sanity/orderable-document-list@1.4.0(@emotion/is-prop-valid@1.2.2)(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(rxjs@7.8.2)(sanity@4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1))(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))":
+  "@sanity/orderable-document-list@1.4.0(@emotion/is-prop-valid@1.2.2)(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(rxjs@7.8.2)(sanity@4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1))(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))":
     dependencies:
       "@hello-pangea/dnd": 18.0.1(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       "@sanity/icons": 3.7.4(react@19.1.1)
@@ -15664,8 +15736,8 @@ snapshots:
       lexorank: 1.0.5
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
-      sanity: 4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1)
-      sanity-plugin-utils: 1.6.8(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(rxjs@7.8.2)(sanity@4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1))(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
+      sanity: 4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1)
+      sanity-plugin-utils: 1.6.8(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(rxjs@7.8.2)(sanity@4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1))(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
       styled-components: 6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
     transitivePeerDependencies:
       - "@emotion/is-prop-valid"
@@ -15673,11 +15745,11 @@ snapshots:
       - react-is
       - rxjs
 
-  "@sanity/presentation-comlink@1.0.28(@sanity/client@7.10.0(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1))":
+  "@sanity/presentation-comlink@1.0.28(@sanity/client@7.10.0)(@sanity/types@4.6.0(@types/react@19.1.11))":
     dependencies:
       "@sanity/client": 7.10.0(debug@4.4.1)
       "@sanity/comlink": 3.0.9
-      "@sanity/visual-editing-types": 1.1.5(@sanity/client@7.10.0(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1))
+      "@sanity/visual-editing-types": 1.1.5(@sanity/client@7.10.0)(@sanity/types@4.6.0(@types/react@19.1.11))
     transitivePeerDependencies:
       - "@sanity/types"
 
@@ -15932,13 +16004,13 @@ snapshots:
   "@sanity/visual-editing-csm@2.0.23(@sanity/client@7.10.0)(@sanity/types@4.6.0(@types/react@19.1.11))(typescript@5.9.2)":
     dependencies:
       "@sanity/client": 7.10.0(debug@4.4.1)
-      "@sanity/visual-editing-types": 1.1.5(@sanity/client@7.10.0(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1))
+      "@sanity/visual-editing-types": 1.1.5(@sanity/client@7.10.0)(@sanity/types@4.6.0(@types/react@19.1.11))
       valibot: 1.1.0(typescript@5.9.2)
     transitivePeerDependencies:
       - "@sanity/types"
       - typescript
 
-  "@sanity/visual-editing-types@1.1.5(@sanity/client@7.10.0(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1))":
+  "@sanity/visual-editing-types@1.1.5(@sanity/client@7.10.0)(@sanity/types@4.6.0(@types/react@19.1.11))":
     dependencies:
       "@sanity/client": 7.10.0(debug@4.4.1)
     optionalDependencies:
@@ -15948,9 +16020,9 @@ snapshots:
     dependencies:
       "@sanity/comlink": 3.0.9
       "@sanity/icons": 3.7.4(react@19.1.1)
-      "@sanity/insert-menu": 2.0.1(@emotion/is-prop-valid@1.2.2)(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1))(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
+      "@sanity/insert-menu": 2.0.1(@emotion/is-prop-valid@1.2.2)(@sanity/types@4.6.0(@types/react@19.1.11))(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
       "@sanity/mutate": 0.11.0-canary.4(xstate@5.20.2)
-      "@sanity/presentation-comlink": 1.0.28(@sanity/client@7.10.0(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1))
+      "@sanity/presentation-comlink": 1.0.28(@sanity/client@7.10.0)(@sanity/types@4.6.0(@types/react@19.1.11))
       "@sanity/preview-url-secret": 2.1.14(@sanity/client@7.10.0(debug@4.4.1))
       "@sanity/ui": 3.0.7(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
       "@sanity/visual-editing-csm": 2.0.23(@sanity/client@7.10.0)(@sanity/types@4.6.0(@types/react@19.1.11))(typescript@5.9.2)
@@ -20362,7 +20434,7 @@ snapshots:
       "@sanity-image/url-builder": 1.0.0
       react: 19.1.1
 
-  sanity-plugin-asset-source-unsplash@4.0.1(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(sanity@4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1))(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1)):
+  sanity-plugin-asset-source-unsplash@4.0.1(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(sanity@4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1))(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1)):
     dependencies:
       "@sanity/icons": 3.7.4(react@19.1.1)
       "@sanity/ui": 3.0.7(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
@@ -20371,13 +20443,13 @@ snapshots:
       react-infinite-scroll-component: 6.1.0(react@19.1.1)
       react-photo-album: 2.4.1(react@19.1.1)
       rxjs: 7.8.2
-      sanity: 4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1)
+      sanity: 4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1)
       styled-components: 6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
     transitivePeerDependencies:
       - "@emotion/is-prop-valid"
       - react-is
 
-  sanity-plugin-icon-picker@4.0.0(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(sanity@4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1)):
+  sanity-plugin-icon-picker@4.0.0(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(sanity@4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1)):
     dependencies:
       "@sanity/incompatible-plugin": 1.0.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       "@sanity/ui": 2.16.2(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
@@ -20389,12 +20461,12 @@ snapshots:
       react-is: 19.1.1
       react-virtualized-auto-sizer: 1.0.25(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react-window: 1.8.11(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      sanity: 4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1)
+      sanity: 4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1)
       styled-components: 6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
     transitivePeerDependencies:
       - "@emotion/is-prop-valid"
 
-  sanity-plugin-media@4.0.0(@emotion/is-prop-valid@1.2.2)(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(sanity@4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1))(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1)):
+  sanity-plugin-media@4.0.0(@emotion/is-prop-valid@1.2.2)(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(sanity@4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1))(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1)):
     dependencies:
       "@hookform/resolvers": 3.10.0(react-hook-form@7.54.2(react@19.1.1))
       "@reduxjs/toolkit": 2.6.1(react-redux@9.2.0(@types/react@19.1.11)(react@19.1.1)(redux@5.0.1))(react@19.1.1)
@@ -20424,7 +20496,7 @@ snapshots:
       redux: 5.0.1
       redux-observable: 3.0.0-rc.2(redux@5.0.1)(rxjs@7.8.2)
       rxjs: 7.8.2
-      sanity: 4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1)
+      sanity: 4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1)
       styled-components: 6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -20433,7 +20505,7 @@ snapshots:
       - debug
       - supports-color
 
-  sanity-plugin-utils@1.6.8(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(rxjs@7.8.2)(sanity@4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1))(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1)):
+  sanity-plugin-utils@1.6.8(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(rxjs@7.8.2)(sanity@4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1))(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1)):
     dependencies:
       "@sanity/icons": 3.7.4(react@19.1.1)
       "@sanity/incompatible-plugin": 1.0.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -20441,14 +20513,14 @@ snapshots:
       react: 19.1.1
       react-fast-compare: 3.2.2
       rxjs: 7.8.2
-      sanity: 4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1)
+      sanity: 4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1)
       styled-components: 6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
     transitivePeerDependencies:
       - "@emotion/is-prop-valid"
       - react-dom
       - react-is
 
-  sanity@4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11)))(@types/node@20.19.11)(@types/react-dom@19.1.7(@types/react@19.1.11))(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1):
+  sanity@4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1):
     dependencies:
       "@dnd-kit/core": 6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       "@dnd-kit/modifiers": 6.0.1(@dnd-kit/core@6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
@@ -20456,177 +20528,8 @@ snapshots:
       "@dnd-kit/utilities": 3.2.2(react@19.1.1)
       "@juggle/resize-observer": 3.4.0
       "@mux/mux-player-react": 3.5.3(@types/react-dom@19.1.7(@types/react@19.1.11))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      "@portabletext/block-tools": 3.5.1(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@types/react@19.1.11)
-      "@portabletext/editor": 2.6.7(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11)))(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rxjs@7.8.2)
-      "@portabletext/react": 4.0.2(react@19.1.1)
-      "@portabletext/toolkit": 3.0.0
-      "@rexxars/react-json-inspector": 9.0.1(react@19.1.1)
-      "@sanity/asset-utils": 2.3.0
-      "@sanity/bifur-client": 0.4.1
-      "@sanity/cli": 4.6.0(@types/node@20.19.11)(@types/react@19.1.11)(lightningcss@1.30.1)(react@19.1.1)(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1)
-      "@sanity/client": 7.10.0(debug@4.4.1)
-      "@sanity/color": 3.0.6
-      "@sanity/comlink": 3.0.9
-      "@sanity/diff": 4.6.0
-      "@sanity/diff-match-patch": 3.2.0
-      "@sanity/diff-patch": 5.0.0
-      "@sanity/eventsource": 5.0.2
-      "@sanity/export": 4.0.1(@types/react@19.1.11)
-      "@sanity/icons": 3.7.4(react@19.1.1)
-      "@sanity/id-utils": 1.0.0
-      "@sanity/image-url": 1.2.0
-      "@sanity/import": 3.38.3(@types/react@19.1.11)
-      "@sanity/insert-menu": 2.0.1(@emotion/is-prop-valid@1.2.2)(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1))(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
-      "@sanity/logos": 2.2.2(react@19.1.1)
-      "@sanity/media-library-types": 1.0.0
-      "@sanity/message-protocol": 0.17.2
-      "@sanity/migrate": 4.6.0(@types/react@19.1.11)
-      "@sanity/mutator": 4.6.0(@types/react@19.1.11)
-      "@sanity/presentation-comlink": 1.0.28(@sanity/client@7.10.0(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1))
-      "@sanity/preview-url-secret": 2.1.14(@sanity/client@7.10.0(debug@4.4.1))
-      "@sanity/schema": 4.6.0(@types/react@19.1.11)(debug@4.4.1)
-      "@sanity/sdk": 2.1.2(@types/react@19.1.11)(debug@4.4.1)(immer@10.1.1)(react@19.1.1)(use-sync-external-store@1.5.0(react@19.1.1))
-      "@sanity/telemetry": 0.8.1(react@19.1.1)
-      "@sanity/types": 4.6.0(@types/react@19.1.11)(debug@4.4.1)
-      "@sanity/ui": 3.0.7(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
-      "@sanity/util": 4.6.0(@types/react@19.1.11)(debug@4.4.1)
-      "@sanity/uuid": 3.0.2
-      "@sentry/react": 8.55.0(react@19.1.1)
-      "@tanstack/react-table": 8.21.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      "@tanstack/react-virtual": 3.13.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      "@types/react-is": 19.0.0
-      "@types/shallow-equals": 1.0.3
-      "@types/speakingurl": 13.0.6
-      "@types/tar-stream": 3.1.4
-      "@types/use-sync-external-store": 1.5.0
-      "@types/which": 3.0.4
-      "@vitejs/plugin-react": 4.7.0(vite@7.1.3(@types/node@20.19.11)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(yaml@2.8.1))
-      "@xstate/react": 6.0.0(@types/react@19.1.11)(react@19.1.1)(xstate@5.20.2)
-      archiver: 7.0.1
-      arrify: 2.0.1
-      async-mutex: 0.5.0
-      chalk: 4.1.2
-      chokidar: 3.6.0
-      classnames: 2.5.1
-      color2k: 2.0.3
-      configstore: 5.0.1
-      console-table-printer: 2.14.6
-      dataloader: 2.2.3
-      date-fns: 2.30.0
-      debug: 4.4.1(supports-color@8.1.1)
-      esbuild: 0.25.9
-      esbuild-register: 3.6.0(esbuild@0.25.9)
-      execa: 2.1.0
-      exif-component: 1.0.1
-      fast-deep-equal: 3.1.3
-      form-data: 4.0.4
-      framer-motion: 12.23.12(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      get-it: 8.6.10(debug@4.4.1)
-      get-random-values-esm: 1.0.2
-      groq-js: 1.17.3
-      gunzip-maybe: 1.4.2
-      history: 5.3.0
-      i18next: 23.16.8
-      import-fresh: 3.3.1
-      is-hotkey-esm: 1.0.0
-      is-tar: 1.0.0
-      isomorphic-dompurify: 2.26.0
-      jsdom: 23.2.0
-      jsdom-global: 3.0.2(jsdom@23.2.0)
-      json-lexer: 1.2.0
-      json-reduce: 3.0.0
-      json5: 2.2.3
-      lodash: 4.17.21
-      log-symbols: 2.2.0
-      mendoza: 3.0.8
-      module-alias: 2.2.3
-      nano-pubsub: 3.0.0
-      nanoid: 3.3.11
-      node-html-parser: 6.1.13
-      observable-callback: 1.0.3(rxjs@7.8.2)
-      oneline: 1.0.4
-      open: 8.4.2
-      p-map: 7.0.3
-      path-to-regexp: 6.3.0
-      peek-stream: 1.1.3
-      pirates: 4.0.7
-      player.style: 0.1.10(react@19.1.1)
-      pluralize-esm: 9.0.5
-      polished: 4.3.1
-      preferred-pm: 4.1.1
-      pretty-ms: 7.0.1
-      quick-lru: 5.1.1
-      raf: 3.4.1
-      react: 19.1.1
-      react-compiler-runtime: 19.1.0-rc.2(react@19.1.1)
-      react-dom: 19.1.1(react@19.1.1)
-      react-fast-compare: 3.2.2
-      react-focus-lock: 2.13.6(@types/react@19.1.11)(react@19.1.1)
-      react-i18next: 15.6.1(i18next@23.16.8)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)
-      react-is: 19.1.1
-      react-refractor: 4.0.0(react@19.1.1)
-      react-rx: 4.1.31(react@19.1.1)(rxjs@7.8.2)
-      read-pkg-up: 7.0.1
-      refractor: 5.0.0
-      resolve-from: 5.0.0
-      resolve.exports: 2.0.3
-      rimraf: 5.0.10
-      rxjs: 7.8.2
-      rxjs-exhaustmap-with-trailing: 2.1.1(rxjs@7.8.2)
-      rxjs-mergemap-array: 0.1.0(rxjs@7.8.2)
-      scroll-into-view-if-needed: 3.1.0
-      scrollmirror: 1.2.4
-      semver: 7.7.2
-      shallow-equals: 1.0.0
-      speakingurl: 14.0.1
-      styled-components: 6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      tar-fs: 2.1.3
-      tar-stream: 3.1.7
-      tinyglobby: 0.2.14
-      urlpattern-polyfill: 10.1.0
-      use-device-pixel-ratio: 1.1.2(react@19.1.1)
-      use-effect-event: 2.0.3(react@19.1.1)
-      use-hot-module-reload: 2.0.0(react@19.1.1)
-      use-sync-external-store: 1.5.0(react@19.1.1)
-      uuid: 11.1.0
-      vite: 7.1.3(@types/node@20.19.11)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(yaml@2.8.1)
-      which: 5.0.0
-      xstate: 5.20.2
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - "@emotion/is-prop-valid"
-      - "@portabletext/sanity-bridge"
-      - "@types/node"
-      - "@types/react"
-      - "@types/react-dom"
-      - bufferutil
-      - canvas
-      - immer
-      - jiti
-      - less
-      - lightningcss
-      - react-native
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - utf-8-validate
-      - yaml
-
-  sanity@4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11)))(@types/node@24.3.0)(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1):
-    dependencies:
-      "@dnd-kit/core": 6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      "@dnd-kit/modifiers": 6.0.1(@dnd-kit/core@6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
-      "@dnd-kit/sortable": 7.0.2(@dnd-kit/core@6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
-      "@dnd-kit/utilities": 3.2.2(react@19.1.1)
-      "@juggle/resize-observer": 3.4.0
-      "@mux/mux-player-react": 3.5.3(@types/react-dom@19.1.7(@types/react@19.1.11))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      "@portabletext/block-tools": 3.5.1(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@types/react@19.1.11)
-      "@portabletext/editor": 2.6.7(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11)))(@sanity/schema@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rxjs@7.8.2)
+      "@portabletext/block-tools": 3.5.1(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11))(@types/react@19.1.11)
+      "@portabletext/editor": 2.6.7(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11)))(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rxjs@7.8.2)
       "@portabletext/react": 4.0.2(react@19.1.1)
       "@portabletext/toolkit": 3.0.0
       "@rexxars/react-json-inspector": 9.0.1(react@19.1.1)
@@ -20645,13 +20548,13 @@ snapshots:
       "@sanity/id-utils": 1.0.0
       "@sanity/image-url": 1.2.0
       "@sanity/import": 3.38.3(@types/react@19.1.11)
-      "@sanity/insert-menu": 2.0.1(@emotion/is-prop-valid@1.2.2)(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1))(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
+      "@sanity/insert-menu": 2.0.1(@emotion/is-prop-valid@1.2.2)(@sanity/types@4.6.0(@types/react@19.1.11))(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
       "@sanity/logos": 2.2.2(react@19.1.1)
       "@sanity/media-library-types": 1.0.0
       "@sanity/message-protocol": 0.17.2
       "@sanity/migrate": 4.6.0(@types/react@19.1.11)
       "@sanity/mutator": 4.6.0(@types/react@19.1.11)
-      "@sanity/presentation-comlink": 1.0.28(@sanity/client@7.10.0(debug@4.4.1))(@sanity/types@4.6.0(@types/react@19.1.11)(debug@4.4.1))
+      "@sanity/presentation-comlink": 1.0.28(@sanity/client@7.10.0)(@sanity/types@4.6.0(@types/react@19.1.11))
       "@sanity/preview-url-secret": 2.1.14(@sanity/client@7.10.0(debug@4.4.1))
       "@sanity/schema": 4.6.0(@types/react@19.1.11)(debug@4.4.1)
       "@sanity/sdk": 2.1.2(@types/react@19.1.11)(debug@4.4.1)(immer@10.1.1)(react@19.1.1)(use-sync-external-store@1.5.0(react@19.1.1))
@@ -20759,6 +20662,175 @@ snapshots:
       use-sync-external-store: 1.5.0(react@19.1.1)
       uuid: 11.1.0
       vite: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(yaml@2.8.1)
+      which: 5.0.0
+      xstate: 5.20.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - "@emotion/is-prop-valid"
+      - "@portabletext/sanity-bridge"
+      - "@types/node"
+      - "@types/react"
+      - "@types/react-dom"
+      - bufferutil
+      - canvas
+      - immer
+      - jiti
+      - less
+      - lightningcss
+      - react-native
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - utf-8-validate
+      - yaml
+
+  sanity@4.6.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11)))(@types/node@20.19.11)(@types/react-dom@19.1.7(@types/react@19.1.11))(@types/react@19.1.11)(immer@10.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1):
+    dependencies:
+      "@dnd-kit/core": 6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      "@dnd-kit/modifiers": 6.0.1(@dnd-kit/core@6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      "@dnd-kit/sortable": 7.0.2(@dnd-kit/core@6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      "@dnd-kit/utilities": 3.2.2(react@19.1.1)
+      "@juggle/resize-observer": 3.4.0
+      "@mux/mux-player-react": 3.5.3(@types/react-dom@19.1.7(@types/react@19.1.11))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      "@portabletext/block-tools": 3.5.1(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11))(@types/react@19.1.11)
+      "@portabletext/editor": 2.6.7(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11)))(@sanity/schema@4.6.0(@types/react@19.1.11))(@sanity/types@4.6.0(@types/react@19.1.11))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rxjs@7.8.2)
+      "@portabletext/react": 4.0.2(react@19.1.1)
+      "@portabletext/toolkit": 3.0.0
+      "@rexxars/react-json-inspector": 9.0.1(react@19.1.1)
+      "@sanity/asset-utils": 2.3.0
+      "@sanity/bifur-client": 0.4.1
+      "@sanity/cli": 4.6.0(@types/node@20.19.11)(@types/react@19.1.11)(lightningcss@1.30.1)(react@19.1.1)(terser@5.37.0)(typescript@5.9.2)(yaml@2.8.1)
+      "@sanity/client": 7.10.0(debug@4.4.1)
+      "@sanity/color": 3.0.6
+      "@sanity/comlink": 3.0.9
+      "@sanity/diff": 4.6.0
+      "@sanity/diff-match-patch": 3.2.0
+      "@sanity/diff-patch": 5.0.0
+      "@sanity/eventsource": 5.0.2
+      "@sanity/export": 4.0.1(@types/react@19.1.11)
+      "@sanity/icons": 3.7.4(react@19.1.1)
+      "@sanity/id-utils": 1.0.0
+      "@sanity/image-url": 1.2.0
+      "@sanity/import": 3.38.3(@types/react@19.1.11)
+      "@sanity/insert-menu": 2.0.1(@emotion/is-prop-valid@1.2.2)(@sanity/types@4.6.0(@types/react@19.1.11))(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
+      "@sanity/logos": 2.2.2(react@19.1.1)
+      "@sanity/media-library-types": 1.0.0
+      "@sanity/message-protocol": 0.17.2
+      "@sanity/migrate": 4.6.0(@types/react@19.1.11)
+      "@sanity/mutator": 4.6.0(@types/react@19.1.11)
+      "@sanity/presentation-comlink": 1.0.28(@sanity/client@7.10.0)(@sanity/types@4.6.0(@types/react@19.1.11))
+      "@sanity/preview-url-secret": 2.1.14(@sanity/client@7.10.0(debug@4.4.1))
+      "@sanity/schema": 4.6.0(@types/react@19.1.11)(debug@4.4.1)
+      "@sanity/sdk": 2.1.2(@types/react@19.1.11)(debug@4.4.1)(immer@10.1.1)(react@19.1.1)(use-sync-external-store@1.5.0(react@19.1.1))
+      "@sanity/telemetry": 0.8.1(react@19.1.1)
+      "@sanity/types": 4.6.0(@types/react@19.1.11)(debug@4.4.1)
+      "@sanity/ui": 3.0.7(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
+      "@sanity/util": 4.6.0(@types/react@19.1.11)(debug@4.4.1)
+      "@sanity/uuid": 3.0.2
+      "@sentry/react": 8.55.0(react@19.1.1)
+      "@tanstack/react-table": 8.21.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      "@tanstack/react-virtual": 3.13.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      "@types/react-is": 19.0.0
+      "@types/shallow-equals": 1.0.3
+      "@types/speakingurl": 13.0.6
+      "@types/tar-stream": 3.1.4
+      "@types/use-sync-external-store": 1.5.0
+      "@types/which": 3.0.4
+      "@vitejs/plugin-react": 4.7.0(vite@7.1.3(@types/node@20.19.11)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(yaml@2.8.1))
+      "@xstate/react": 6.0.0(@types/react@19.1.11)(react@19.1.1)(xstate@5.20.2)
+      archiver: 7.0.1
+      arrify: 2.0.1
+      async-mutex: 0.5.0
+      chalk: 4.1.2
+      chokidar: 3.6.0
+      classnames: 2.5.1
+      color2k: 2.0.3
+      configstore: 5.0.1
+      console-table-printer: 2.14.6
+      dataloader: 2.2.3
+      date-fns: 2.30.0
+      debug: 4.4.1(supports-color@8.1.1)
+      esbuild: 0.25.9
+      esbuild-register: 3.6.0(esbuild@0.25.9)
+      execa: 2.1.0
+      exif-component: 1.0.1
+      fast-deep-equal: 3.1.3
+      form-data: 4.0.4
+      framer-motion: 12.23.12(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      get-it: 8.6.10(debug@4.4.1)
+      get-random-values-esm: 1.0.2
+      groq-js: 1.17.3
+      gunzip-maybe: 1.4.2
+      history: 5.3.0
+      i18next: 23.16.8
+      import-fresh: 3.3.1
+      is-hotkey-esm: 1.0.0
+      is-tar: 1.0.0
+      isomorphic-dompurify: 2.26.0
+      jsdom: 23.2.0
+      jsdom-global: 3.0.2(jsdom@23.2.0)
+      json-lexer: 1.2.0
+      json-reduce: 3.0.0
+      json5: 2.2.3
+      lodash: 4.17.21
+      log-symbols: 2.2.0
+      mendoza: 3.0.8
+      module-alias: 2.2.3
+      nano-pubsub: 3.0.0
+      nanoid: 3.3.11
+      node-html-parser: 6.1.13
+      observable-callback: 1.0.3(rxjs@7.8.2)
+      oneline: 1.0.4
+      open: 8.4.2
+      p-map: 7.0.3
+      path-to-regexp: 6.3.0
+      peek-stream: 1.1.3
+      pirates: 4.0.7
+      player.style: 0.1.10(react@19.1.1)
+      pluralize-esm: 9.0.5
+      polished: 4.3.1
+      preferred-pm: 4.1.1
+      pretty-ms: 7.0.1
+      quick-lru: 5.1.1
+      raf: 3.4.1
+      react: 19.1.1
+      react-compiler-runtime: 19.1.0-rc.2(react@19.1.1)
+      react-dom: 19.1.1(react@19.1.1)
+      react-fast-compare: 3.2.2
+      react-focus-lock: 2.13.6(@types/react@19.1.11)(react@19.1.1)
+      react-i18next: 15.6.1(i18next@23.16.8)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)
+      react-is: 19.1.1
+      react-refractor: 4.0.0(react@19.1.1)
+      react-rx: 4.1.31(react@19.1.1)(rxjs@7.8.2)
+      read-pkg-up: 7.0.1
+      refractor: 5.0.0
+      resolve-from: 5.0.0
+      resolve.exports: 2.0.3
+      rimraf: 5.0.10
+      rxjs: 7.8.2
+      rxjs-exhaustmap-with-trailing: 2.1.1(rxjs@7.8.2)
+      rxjs-mergemap-array: 0.1.0(rxjs@7.8.2)
+      scroll-into-view-if-needed: 3.1.0
+      scrollmirror: 1.2.4
+      semver: 7.7.2
+      shallow-equals: 1.0.0
+      speakingurl: 14.0.1
+      styled-components: 6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      tar-fs: 2.1.3
+      tar-stream: 3.1.7
+      tinyglobby: 0.2.14
+      urlpattern-polyfill: 10.1.0
+      use-device-pixel-ratio: 1.1.2(react@19.1.1)
+      use-effect-event: 2.0.3(react@19.1.1)
+      use-hot-module-reload: 2.0.0(react@19.1.1)
+      use-sync-external-store: 1.5.0(react@19.1.1)
+      uuid: 11.1.0
+      vite: 7.1.3(@types/node@20.19.11)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(yaml@2.8.1)
       which: 5.0.0
       xstate: 5.20.2
       yargs: 17.7.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       framer-motion:
         specifier: ^11.18.2
         version: 11.18.2(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      fuse.js:
+        specifier: ^7.1.0
+        version: 7.1.0
       lucide-react:
         specifier: ^0.539.0
         version: 0.539.0(react@19.1.1)
@@ -7183,6 +7186,13 @@ packages:
       {
         integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==,
       }
+
+  fuse.js@7.1.0:
+    resolution:
+      {
+        integrity: sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==,
+      }
+    engines: { node: ">=10" }
 
   gensync@1.0.0-beta.2:
     resolution:
@@ -18137,6 +18147,8 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  fuse.js@7.1.0: {}
 
   gensync@1.0.0-beta.2: {}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Sauces Index at /sauces: SSR list with client-side fuzzy search, product-line multi-select, sauce-type single-select, A→Z/Z→A sorting, URL deep-linking, responsive filters (sidebar desktop, sheet mobile), and sauce cards grid.
  - Basic sauce detail page at /sauces/[slug].

- **Accessibility**
  - Live result-count announcements and improved ARIA for filters and cards.

- **UI**
  - Site-wide Eyebrow component replaces prior eyebrow badges; badge visuals refreshed; improved mobile filter sheet/controls.

- **Documentation**
  - Expanded Sanity workflow guidance and a Sauces Index PRD/implementation plan.

- **Chores**
  - Added fuse.js dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->