### PR TITLE
feat(studio): add slug field to product and recipe types, implement slug backfill script

### DIFF
--- a/.changeset/add-sauce-pages-to-sitemap.md
+++ b/.changeset/add-sauce-pages-to-sitemap.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Include `sauce` documents in the sitemap alongside pages, blogs, products, and recipes.

--- a/.changeset/add-slugs-to-products-and-recipes.md
+++ b/.changeset/add-slugs-to-products-and-recipes.md
@@ -1,0 +1,10 @@
+---
+"studio": minor
+"web": patch
+---
+
+Add slug fields to Product and Recipe schemas and add a slug backfill script for the development dataset.
+
+- Add `slug` field to `productType` and `recipeType` documents in Studio
+- Implement `apps/studio/scripts/backfill-slugs.ts` to populate slugs for all Product and Recipe documents in the dev dataset
+- Regenerate Sanity types consumed by Web (`sanity.types.ts`)

--- a/.changeset/dedupe-slug-uniqueness-validation.md
+++ b/.changeset/dedupe-slug-uniqueness-validation.md
@@ -1,0 +1,9 @@
+---
+"studio": patch
+---
+
+Deduplicate slug uniqueness validation by removing `options.isUnique` wherever a custom uniqueness rule already exists.
+
+- Use `Rule.custom(createUniqueSlugRule())` as the single source of truth
+- Drop redundant `isUnique` from slug field options in content docs (blog, page, product, recipe, sauce)
+- Keep index docs as-is since they only use `isUnique` and have no duplication

--- a/.changeset/harden-createSlug-mapper-support.md
+++ b/.changeset/harden-createSlug-mapper-support.md
@@ -1,0 +1,10 @@
+---
+"studio": patch
+---
+
+Harden `createSlug` to safely support string and function mappers.
+
+- Accept mapper values that are strings (fixed paths) or functions (computed)
+- Treat strings ending with `/` as prefixes to compose with slugified input
+- Normalize output (leading slash, collapse `//`, trim trailing slash)
+- Preserve existing behavior for index docs (`/`, `/blog`, `/products`, etc.)

--- a/.changeset/og-fallbacks-for-product-and-recipe.md
+++ b/.changeset/og-fallbacks-for-product-and-recipe.md
@@ -1,0 +1,9 @@
+---
+"web": patch
+---
+
+Improve OG data for products and recipes and extend sitemap coverage.
+
+- Add fallbacks in OG projections: use `name` when `ogTitle/seoTitle/title` are missing; prefer `pt::text(description)` for product/recipe, fallback to `name`.
+- Prefer `mainImage` (and its dominant color) before `image` to avoid null OG images.
+- Add `product` and `recipe` pages to the sitemap query and generation.

--- a/apps/studio/schema.json
+++ b/apps/studio/schema.json
@@ -3927,6 +3927,14 @@
         },
         "optional": false
       },
+      "slug": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "slug"
+        },
+        "optional": false
+      },
       "versions": {
         "type": "objectAttribute",
         "value": {
@@ -5287,6 +5295,14 @@
         "type": "objectAttribute",
         "value": {
           "type": "string"
+        },
+        "optional": false
+      },
+      "slug": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "slug"
         },
         "optional": false
       },

--- a/apps/studio/schemaTypes/documents/blog.ts
+++ b/apps/studio/schemaTypes/documents/blog.ts
@@ -9,7 +9,7 @@ import { PathnameFieldComponent } from "../../components/slug-field-component";
 import { GROUP, GROUPS } from "../../utils/constant";
 import { ogFields } from "../../utils/og-fields";
 import { seoFields } from "../../utils/seo-fields";
-import { createSlug, isUnique } from "../../utils/slug";
+import { createSlug } from "../../utils/slug";
 import {
   createSlugValidator,
   createUniqueSlugRule,
@@ -68,7 +68,6 @@ export const blog = defineType({
       options: {
         source: "title",
         slugify: createSlug,
-        isUnique,
       },
       validation: (Rule) => [
         Rule.required().error("A URL slug is required"),

--- a/apps/studio/schemaTypes/documents/page.ts
+++ b/apps/studio/schemaTypes/documents/page.ts
@@ -5,7 +5,7 @@ import { PathnameFieldComponent } from "../../components/slug-field-component";
 import { GROUP, GROUPS } from "../../utils/constant";
 import { ogFields } from "../../utils/og-fields";
 import { seoFields } from "../../utils/seo-fields";
-import { createSlug, isUnique } from "../../utils/slug";
+import { createSlug } from "../../utils/slug";
 import {
   createSlugValidator,
   createUniqueSlugRule,
@@ -64,7 +64,6 @@ export const page = defineType({
       options: {
         source: "title",
         slugify: createSlug,
-        isUnique,
       },
       validation: (Rule) =>
         Rule.required()

--- a/apps/studio/schemaTypes/documents/productType.ts
+++ b/apps/studio/schemaTypes/documents/productType.ts
@@ -3,7 +3,7 @@ import { defineArrayMember, defineField, defineType } from "sanity";
 
 import { USDPriceInput } from "../../components/inputs/USDPriceInput";
 import { PathnameFieldComponent } from "../../components/slug-field-component";
-import { createSlug, isUnique } from "../../utils/slug";
+import { createSlug } from "../../utils/slug";
 import {
   createSlugValidator,
   createUniqueSlugRule,
@@ -43,7 +43,6 @@ export const productType = defineType({
       options: {
         source: "name",
         slugify: createSlug,
-        isUnique,
       },
       validation: (Rule) => [
         Rule.required().error("A URL slug is required"),

--- a/apps/studio/schemaTypes/documents/productType.ts
+++ b/apps/studio/schemaTypes/documents/productType.ts
@@ -2,6 +2,12 @@ import { ControlsIcon, PackageIcon, TagIcon } from "@sanity/icons"; // Assuming 
 import { defineArrayMember, defineField, defineType } from "sanity";
 
 import { USDPriceInput } from "../../components/inputs/USDPriceInput";
+import { PathnameFieldComponent } from "../../components/slug-field-component";
+import { createSlug, isUnique } from "../../utils/slug";
+import {
+  createSlugValidator,
+  createUniqueSlugRule,
+} from "../../utils/slug-validation";
 
 export const productType = defineType({
   name: "product",
@@ -23,6 +29,32 @@ export const productType = defineType({
       type: "string",
       group: "basic",
       validation: (Rule) => Rule.required().error("Product name is required."),
+    }),
+    defineField({
+      name: "slug",
+      type: "slug",
+      title: "URL",
+      description:
+        "The web address for this product (automatically created from its name)",
+      group: "basic",
+      components: {
+        field: PathnameFieldComponent,
+      },
+      options: {
+        source: "name",
+        slugify: createSlug,
+        isUnique,
+      },
+      validation: (Rule) => [
+        Rule.required().error("A URL slug is required"),
+        Rule.custom(createUniqueSlugRule()),
+        Rule.custom(
+          createSlugValidator({
+            documentType: "Product",
+            requiredPrefix: "/products/",
+          }),
+        ),
+      ],
     }),
     defineField({
       name: "sku",

--- a/apps/studio/schemaTypes/documents/recipeType.ts
+++ b/apps/studio/schemaTypes/documents/recipeType.ts
@@ -8,7 +8,7 @@ import type { SanityDocument } from "sanity";
 import { defineArrayMember, defineField, defineType } from "sanity";
 
 import { PathnameFieldComponent } from "../../components/slug-field-component";
-import { createSlug, isUnique } from "../../utils/slug";
+import { createSlug } from "../../utils/slug";
 import {
   createSlugValidator,
   createUniqueSlugRule,
@@ -70,7 +70,6 @@ export const recipeType = defineType({
       options: {
         source: "name",
         slugify: createSlug,
-        isUnique,
       },
       validation: (Rule) => [
         Rule.required().error("A URL slug is required"),

--- a/apps/studio/schemaTypes/documents/recipeType.ts
+++ b/apps/studio/schemaTypes/documents/recipeType.ts
@@ -7,6 +7,13 @@ import {
 import type { SanityDocument } from "sanity";
 import { defineArrayMember, defineField, defineType } from "sanity";
 
+import { PathnameFieldComponent } from "../../components/slug-field-component";
+import { createSlug, isUnique } from "../../utils/slug";
+import {
+  createSlugValidator,
+  createUniqueSlugRule,
+} from "../../utils/slug-validation";
+
 const isVersionSelected = (
   document: (SanityDocument & { versions?: string[] }) | undefined,
   version: string,
@@ -49,6 +56,32 @@ export const recipeType = defineType({
       validation: (Rule) =>
         Rule.required().error("A name is required for the recipe."),
       group: "basic",
+    }),
+    defineField({
+      name: "slug",
+      type: "slug",
+      title: "URL",
+      description:
+        "The web address for this recipe (automatically created from its name)",
+      group: "basic",
+      components: {
+        field: PathnameFieldComponent,
+      },
+      options: {
+        source: "name",
+        slugify: createSlug,
+        isUnique,
+      },
+      validation: (Rule) => [
+        Rule.required().error("A URL slug is required"),
+        Rule.custom(createUniqueSlugRule()),
+        Rule.custom(
+          createSlugValidator({
+            documentType: "Recipe",
+            requiredPrefix: "/recipes/",
+          }),
+        ),
+      ],
     }),
     defineField({
       name: "versions",

--- a/apps/studio/schemaTypes/documents/sauce.ts
+++ b/apps/studio/schemaTypes/documents/sauce.ts
@@ -10,7 +10,7 @@ import { defineField, defineType } from "sanity";
 import type { AltTextFromFieldOptions } from "../../components/inputs/AltTextFromField";
 import { AltTextFromField } from "../../components/inputs/AltTextFromField";
 import { PathnameFieldComponent } from "../../components/slug-field-component";
-import { createSlug, isUnique } from "../../utils/slug";
+import { createSlug } from "../../utils/slug";
 import {
   createSlugValidator,
   createUniqueSlugRule,
@@ -62,7 +62,6 @@ export const sauce = defineType({
       options: {
         source: "name",
         slugify: createSlug,
-        isUnique,
       },
       validation: (Rule) => [
         Rule.required().error("A URL slug is required"),

--- a/apps/studio/scripts/backfill-slugs.ts
+++ b/apps/studio/scripts/backfill-slugs.ts
@@ -1,0 +1,216 @@
+/**
+ * One-time slug backfill for product and recipe documents.
+ *
+ * Usage (dry run first):
+ *   pnpm -C apps/studio sanity exec scripts/backfill-slugs.ts -- --dry
+ *
+ * Apply changes:
+ *   pnpm -C apps/studio sanity exec scripts/backfill-slugs.ts -- --with-user-token
+ *
+ * Options:
+ *   --dry               Preview changes without writing
+ *   --types=a,b         Comma-separated doc types to process (default: product,recipe)
+ *   --fix-prefix        Also fix existing slugs with wrong prefix
+ *   --limit=N           Limit number of documents to process
+ */
+
+import "dotenv/config";
+
+import type { SlugSchemaType } from "sanity";
+import { getCliClient } from "sanity/cli";
+
+import { createSlug, getDocTypePrefix } from "../utils/slug";
+
+type DocType = "product" | "recipe";
+
+interface Doc {
+  _id: string;
+  _type: DocType;
+  name?: string;
+  title?: string;
+  slug?: { current?: string };
+}
+
+const apiVersion = "2025-05-08";
+
+function parseArgs(argv: string[]) {
+  const args = new Set(argv);
+  const getValue = (key: string) => {
+    const idx = argv.indexOf(key);
+    return idx >= 0 ? argv[idx + 1] : undefined;
+  };
+
+  const dry = args.has("--dry") || args.has("--dry-run");
+  const typesArg = getValue("--types");
+  const types = (typesArg?.split(",").map((t) => t.trim()) || [
+    "product",
+    "recipe",
+  ]) as DocType[];
+  const limit = getValue("--limit");
+  const fixPrefix = args.has("--fix-prefix");
+
+  return { dry, types, limit: limit ? Number(limit) : undefined, fixPrefix };
+}
+
+function toPublishedId(id: string): string {
+  return id.replace(/^drafts\./, "");
+}
+
+function toDraftId(id: string): string {
+  return id.startsWith("drafts.") ? id : `drafts.${id}`;
+}
+
+function hasCorrectPrefix(slug: string | undefined, type: DocType): boolean {
+  if (!slug) return false;
+  const expected = `/${getDocTypePrefix(type)}/`;
+  return slug.startsWith(expected);
+}
+
+async function slugExists(
+  client: any,
+  slug: string,
+  excludeBaseId: string,
+): Promise<boolean> {
+  const params = {
+    slug,
+    draft: `drafts.${excludeBaseId}`,
+    published: excludeBaseId,
+  };
+  const query = `*[
+    slug.current == $slug && !(_id in [$draft, $published])
+  ][0]._id`;
+  const dup = (await client.fetch(query, params)) as string | null;
+  return Boolean(dup);
+}
+
+async function ensureUniqueSlug(
+  client: any,
+  baseSlug: string,
+  baseId: string,
+): Promise<string> {
+  // If unused, return as-is
+  if (!(await slugExists(client, baseSlug, baseId))) return baseSlug;
+
+  const lastSlash = baseSlug.lastIndexOf("/");
+  const prefix = baseSlug.slice(0, lastSlash + 1); // includes trailing /
+  const segment = baseSlug.slice(lastSlash + 1);
+
+  let n = 2;
+  while (true) {
+    const candidate = `${prefix}${segment}-${n}`;
+    if (!(await slugExists(client, candidate, baseId))) return candidate;
+    n++;
+  }
+}
+
+function deriveSourceValue(doc: Doc): string | undefined {
+  // Our schemas use `name` for product/recipe
+  return doc.name || doc.title;
+}
+
+async function generateSlugForDoc(doc: Doc): Promise<string | undefined> {
+  const source = deriveSourceValue(doc);
+  if (!source) return undefined;
+  // Reuse the studio slugifier to maintain identical output
+  const slugFn = createSlug as unknown as (
+    input: string,
+    type: SlugSchemaType,
+    context: { parent?: unknown },
+  ) => string | Promise<string>;
+  const out = slugFn(source, undefined as unknown as SlugSchemaType, {
+    parent: { _type: doc._type },
+  });
+  return out instanceof Promise ? await out : out;
+}
+
+async function backfill() {
+  const { dry, types, limit, fixPrefix } = parseArgs(process.argv.slice(2));
+  const baseClient = getCliClient({ apiVersion });
+  const token =
+    process.env.SANITY_AUTH_TOKEN || process.env.SANITY_API_WRITE_TOKEN;
+  const client = token ? baseClient.withConfig({ token }) : baseClient;
+
+  if (!token) {
+    console.log(
+      "[auth] No SANITY_AUTH_TOKEN/SANITY_API_WRITE_TOKEN found; relying on CLI user token if provided (use --with-user-token) or set a write token.",
+    );
+  } else {
+    console.log("[auth] Using service API token from environment.");
+  }
+
+  console.log(
+    `Running slug backfill (dry=${dry}) for types: ${types.join(", ")}`,
+  );
+
+  // Only fetch published docs to avoid duplicates; we'll patch draft too if it exists.
+  const query = `*[_type in $types && !(_id in path("drafts.**"))]{_id,_type,name,title,slug}`;
+  let docs = (await client.fetch(query, { types })) as Doc[];
+
+  // Filter docs needing attention
+  docs = docs.filter((d) => {
+    const missing = !d.slug?.current || d.slug.current.trim() === "";
+    const wrongPrefix =
+      !missing && fixPrefix && !hasCorrectPrefix(d.slug?.current, d._type);
+    return missing || wrongPrefix;
+  });
+
+  if (limit && Number.isFinite(limit)) docs = docs.slice(0, limit);
+
+  if (docs.length === 0) {
+    console.log("No documents require slug backfill.");
+    return;
+  }
+
+  console.log(`Found ${docs.length} documents to update.`);
+
+  let updated = 0;
+  for (const doc of docs) {
+    const baseId = toPublishedId(doc._id);
+    const suggested = await generateSlugForDoc(doc);
+    if (!suggested) {
+      console.warn(
+        `Skipping ${doc._id} (${doc._type}): missing source (name/title).`,
+      );
+      continue;
+    }
+
+    const finalSlug = await ensureUniqueSlug(client, suggested, baseId);
+
+    if (dry) {
+      console.log(
+        `DRY: ${doc._id} (${doc._type}) -> ${doc.slug?.current ?? "<none>"} => ${finalSlug}`,
+      );
+      continue;
+    }
+
+    // Always patch published; patch draft only if it exists
+    const patchPublished = client
+      .patch(baseId)
+      .set({ slug: { _type: "slug", current: finalSlug } });
+
+    const draftId = toDraftId(baseId);
+    const hasDraft = (await client.fetch("defined(*[_id == $id][0]._id)", {
+      id: draftId,
+    })) as boolean;
+
+    const tx = client.transaction().patch(patchPublished);
+    if (hasDraft) {
+      tx.patch(
+        client
+          .patch(draftId)
+          .set({ slug: { _type: "slug", current: finalSlug } }),
+      );
+    }
+    await tx.commit({ visibility: "async" });
+
+    updated++;
+    console.log(`Updated ${doc._id} -> ${finalSlug}`);
+  }
+
+  console.log(`Done. Updated ${updated} document(s).`);
+}
+
+backfill().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/studio/utils/slug-validation.ts
+++ b/apps/studio/utils/slug-validation.ts
@@ -100,6 +100,16 @@ function getDocumentTypeConfig(
         documentType: "Sauce",
         requiredPrefix: "/sauces/",
       };
+    case "product":
+      return {
+        documentType: "Product",
+        requiredPrefix: "/products/",
+      };
+    case "recipe":
+      return {
+        documentType: "Recipe",
+        requiredPrefix: "/recipes/",
+      };
     case "blogIndex":
       return {
         documentType: "Blog index",
@@ -109,6 +119,16 @@ function getDocumentTypeConfig(
       return {
         documentType: "Sauce index",
         requiredPrefix: "/sauces",
+      };
+    case "productIndex":
+      return {
+        documentType: "Product index",
+        requiredPrefix: "/products",
+      };
+    case "recipeIndex":
+      return {
+        documentType: "Recipe index",
+        requiredPrefix: "/recipes",
       };
     case "homePage":
       return {
@@ -346,6 +366,18 @@ function applyDocumentTypeRules(
         return "/sauces";
       }
       return slug;
+    case "productIndex":
+      // Product index should be exactly /products
+      if (slug !== "/products") {
+        return "/products";
+      }
+      return slug;
+    case "recipeIndex":
+      // Recipe index should be exactly /recipes
+      if (slug !== "/recipes") {
+        return "/recipes";
+      }
+      return slug;
 
     case "sauce":
       // Ensure sauces live under /sauces/
@@ -355,6 +387,26 @@ function applyDocumentTypeRules(
         }
         const cleanPath = slug.replace(/^\/+/, "");
         return `/sauces/${cleanPath}`;
+      }
+      return slug;
+    case "product":
+      // Ensure products live under /products/
+      if (!slug.startsWith("/products/")) {
+        if (slug === "/" || slug === "/products") {
+          return "/products/untitled";
+        }
+        const cleanPath = slug.replace(/^\/+/, "");
+        return `/products/${cleanPath}`;
+      }
+      return slug;
+    case "recipe":
+      // Ensure recipes live under /recipes/
+      if (!slug.startsWith("/recipes/")) {
+        if (slug === "/" || slug === "/recipes") {
+          return "/recipes/untitled";
+        }
+        const cleanPath = slug.replace(/^\/+/, "");
+        return `/recipes/${cleanPath}`;
       }
       return slug;
 

--- a/apps/studio/utils/slug.ts
+++ b/apps/studio/utils/slug.ts
@@ -52,6 +52,8 @@ export async function isUnique(
 export const getDocTypePrefix = (type: string) => {
   if (["page"].includes(type)) return "";
   if (type === "sauce") return "sauces";
+  if (type === "product") return "products";
+  if (type === "recipe") return "recipes";
   return type;
 };
 
@@ -59,6 +61,8 @@ const slugMapper = {
   homePage: "/",
   blogIndex: "/blog",
   sauceIndex: "/sauces",
+  productIndex: "/products",
+  recipeIndex: "/recipes",
 } as Record<string, string>;
 
 export const createSlug: SlugifierFn = (input, _, { parent }) => {

--- a/apps/studio/utils/slug.ts
+++ b/apps/studio/utils/slug.ts
@@ -57,27 +57,62 @@ export const getDocTypePrefix = (type: string) => {
   return type;
 };
 
-const slugMapper = {
+type SlugMapValue =
+  | string
+  | ((
+      input: string,
+      parent: { _type?: string } | undefined,
+    ) => string | undefined | null);
+
+const slugMapper: Record<string, SlugMapValue> = {
   homePage: "/",
   blogIndex: "/blog",
   sauceIndex: "/sauces",
   productIndex: "/products",
   recipeIndex: "/recipes",
-} as Record<string, string>;
+};
+
+function normalizePath(path: string): string {
+  if (!path) return "/";
+  // Ensure string and trim whitespace
+  let p = String(path).trim();
+  // Guarantee leading slash
+  if (!p.startsWith("/")) p = `/${p}`;
+  // Collapse multiple slashes
+  p = p.replace(/\/+/, "/");
+  // Remove trailing slash unless root
+  if (p.length > 1 && p.endsWith("/")) p = p.slice(0, -1);
+  return p;
+}
 
 export const createSlug: SlugifierFn = (input, _, { parent }) => {
-  const { _type } = parent as {
-    _type: string;
-  };
+  const { _type } = (parent || {}) as { _type?: string };
 
-  if (slugMapper[_type]) return slugMapper[_type];
+  const map = _type ? slugMapper[_type] : undefined;
+  if (typeof map === "function") {
+    const computed = map(input, parent as any);
+    if (typeof computed === "string" && computed.trim().length > 0) {
+      return normalizePath(computed);
+    }
+    // fall through to default generation if mapper returned invalid
+  } else if (typeof map === "string") {
+    const mapped = map.trim();
+    // If mapper string ends with '/', treat as a prefix to compose
+    if (mapped.endsWith("/")) {
+      const base = mapped;
+      const seg = slugify(input, { lower: true, remove: /[^a-zA-Z0-9 ]/g });
+      return normalizePath(`${base}${seg}`);
+    }
+    // Otherwise treat as an absolute, fixed path (preserves current index behavior)
+    return normalizePath(mapped);
+  }
 
-  const prefix = getDocTypePrefix(_type);
-
-  const slug = slugify(input, {
+  const prefix = getDocTypePrefix(_type || "");
+  const seg = slugify(input, {
     lower: true,
     remove: /[^a-zA-Z0-9 ]/g,
   });
 
-  return `/${[prefix, slug].filter(Boolean).join("/")}`;
+  const joined = `/${[prefix, seg].filter(Boolean).join("/")}`;
+  return normalizePath(joined);
 };

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -6,8 +6,17 @@ import { getBaseUrl } from "@/utils";
 
 const baseUrl = getBaseUrl();
 
+type SitemapEntry = { slug: string; lastModified?: string };
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const { slugPages, blogPages } = await client.fetch(querySitemapData);
+  const { slugPages, blogPages, saucePages, productPages, recipePages } =
+    (await client.fetch(querySitemapData)) as {
+      slugPages: SitemapEntry[];
+      blogPages: SitemapEntry[];
+      saucePages: SitemapEntry[];
+      productPages: SitemapEntry[];
+      recipePages: SitemapEntry[];
+    };
   return [
     {
       url: baseUrl,
@@ -15,17 +24,35 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: "weekly",
       priority: 1,
     },
-    ...slugPages.map((page) => ({
+    ...slugPages.map((page: SitemapEntry) => ({
       url: `${baseUrl}${page.slug}`,
       lastModified: new Date(page.lastModified ?? new Date()),
       changeFrequency: "weekly" as const,
       priority: 0.8,
     })),
-    ...blogPages.map((page) => ({
+    ...blogPages.map((page: SitemapEntry) => ({
       url: `${baseUrl}${page.slug}`,
       lastModified: new Date(page.lastModified ?? new Date()),
       changeFrequency: "weekly" as const,
       priority: 0.5,
+    })),
+    ...saucePages.map((page: SitemapEntry) => ({
+      url: `${baseUrl}${page.slug}`,
+      lastModified: new Date(page.lastModified ?? new Date()),
+      changeFrequency: "weekly" as const,
+      priority: 0.7,
+    })),
+    ...productPages.map((page: SitemapEntry) => ({
+      url: `${baseUrl}${page.slug}`,
+      lastModified: new Date(page.lastModified ?? new Date()),
+      changeFrequency: "weekly" as const,
+      priority: 0.6,
+    })),
+    ...recipePages.map((page: SitemapEntry) => ({
+      url: `${baseUrl}${page.slug}`,
+      lastModified: new Date(page.lastModified ?? new Date()),
+      changeFrequency: "weekly" as const,
+      priority: 0.6,
     })),
   ];
 }

--- a/apps/web/src/lib/sanity/query.ts
+++ b/apps/web/src/lib/sanity/query.ts
@@ -260,16 +260,27 @@ const ogFieldsFragment = /* groq */ `
     defined(ogTitle) => ogTitle,
     defined(seoTitle) => seoTitle,
     _type == "sauce" => name,
+    _type == "product" => name,
+    _type == "recipe" => name,
     title
   )), ""),
   "description": coalesce(string(select(
     defined(ogDescription) => ogDescription,
     defined(seoDescription) => seoDescription,
     _type == "sauce" => pt::text(description),
+    _type == "product" => coalesce(pt::text(description), name),
+    _type == "recipe" => coalesce(pt::text(description), name),
     description
   )), ""),
-  "image": image.asset->url + "?w=566&h=566&dpr=2&fit=max",
-  "dominantColor": image.asset->metadata.palette.dominant.background,
+  // Prefer mainImage (product/recipe) and fall back to image
+  "image": coalesce(
+    mainImage.asset->url,
+    image.asset->url
+  ) + "?w=566&h=566&dpr=2&fit=max",
+  "dominantColor": coalesce(
+    mainImage.asset->metadata.palette.dominant.background,
+    image.asset->metadata.palette.dominant.background
+  ),
   "seoImage": seoImage.asset->url + "?w=1200&h=630&dpr=2&fit=max",
   "date": coalesce(date, _createdAt)
 `;
@@ -362,6 +373,18 @@ export const querySitemapData = defineQuery(`{
     "lastModified": _updatedAt
   },
   "blogPages": *[_type == "blog" && defined(slug.current)]{
+    "slug": slug.current,
+    "lastModified": _updatedAt
+  },
+  "saucePages": *[_type == "sauce" && defined(slug.current)]{
+    "slug": slug.current,
+    "lastModified": _updatedAt
+  },
+  "productPages": *[_type == "product" && defined(slug.current)]{
+    "slug": slug.current,
+    "lastModified": _updatedAt
+  },
+  "recipePages": *[_type == "recipe" && defined(slug.current)]{
     "slug": slug.current,
     "lastModified": _updatedAt
   }

--- a/apps/web/src/lib/sanity/sanity.types.ts
+++ b/apps/web/src/lib/sanity/sanity.types.ts
@@ -588,6 +588,7 @@ export type Recipe = {
   _updatedAt: string;
   _rev: string;
   name: string;
+  slug: Slug;
   versions: Array<string>;
   dgfSauces?: Array<{
     _ref: string;
@@ -743,6 +744,7 @@ export type Product = {
   _updatedAt: string;
   _rev: string;
   name: string;
+  slug: Slug;
   sku: string;
   category: "case_of_12" | "gift_pack" | "merchandise";
   shippingCategory: "normal_item" | "large_crate" | "gift_pack";
@@ -3014,12 +3016,32 @@ export type QueryGenericPageOGDataResult =
     }
   | {
       _id: string;
+      _type: "product";
+      title: "";
+      description: "";
+      image: null;
+      dominantColor: null;
+      seoImage: null;
+      date: string;
+    }
+  | {
+      _id: string;
       _type: "productIndex";
       title: string | "";
       description: string | "";
       image: null;
       dominantColor: null;
       seoImage: string | null;
+      date: string;
+    }
+  | {
+      _id: string;
+      _type: "recipe";
+      title: "";
+      description: "";
+      image: null;
+      dominantColor: null;
+      seoImage: null;
       date: string;
     }
   | {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added human-readable URLs (slugs) for Products and Recipes, auto-generated from names and validated for uniqueness.
  * Standardized index paths to /products and /recipes.

* Bug Fixes
  * Enforced correct URL prefixes (/products/ and /recipes/) and normalized invalid or missing slugs to avoid broken links.

* Chores
  * Backfilled slugs for existing Product and Recipe content (dry-run supported).
  * Updated web app types to include slugs and recognize Product/Recipe in OG data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->