### PR TITLE
fix: update parameter types in Blog and Recipe detail pages to use Promise for slug

### DIFF
--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -31,9 +31,9 @@ async function fetchBlogPaths() {
 export async function generateMetadata({
   params,
 }: {
-  params: { slug: string };
+  params: Promise<{ slug: string }>;
 }): Promise<Metadata> {
-  const { slug } = params;
+  const { slug } = await params;
   const { data } = await fetchBlogSlugPageData(slug, false);
   return getSEOMetadata(
     data
@@ -56,9 +56,9 @@ export async function generateStaticParams() {
 export default async function BlogSlugPage({
   params,
 }: {
-  params: { slug: string };
+  params: Promise<{ slug: string }>;
 }) {
-  const { slug } = params;
+  const { slug } = await params;
   const { data } = await fetchBlogSlugPageData(slug);
   if (!data) return notFound();
   const { title, description, image, richText } = data ?? {};

--- a/apps/web/src/app/recipes/[slug]/page.tsx
+++ b/apps/web/src/app/recipes/[slug]/page.tsx
@@ -6,9 +6,9 @@ import { getSEOMetadata } from "@/lib/seo";
 export async function generateMetadata({
   params,
 }: {
-  params: { slug: string };
+  params: Promise<{ slug: string }>;
 }): Promise<Metadata> {
-  const { slug } = params;
+  const { slug } = await params;
   return getSEOMetadata({
     title: `Recipe: ${slug}`,
     description: "Recipe details coming soon.",
@@ -20,9 +20,9 @@ export async function generateMetadata({
 export default async function RecipeDetailPage({
   params,
 }: {
-  params: { slug: string };
+  params: Promise<{ slug: string }>;
 }) {
-  const { slug } = params;
+  const { slug } = await params;
   return (
     <main>
       <div className="container my-16 mx-auto px-4 md:px-6">


### PR DESCRIPTION
- Changed the parameter type for `slug` in `generateMetadata` and `RecipeDetailPage` functions to `Promise<{ slug: string }>` to align with Next.js 15's contract and ensure proper async handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated Blog and Recipe detail pages to use asynchronous route parameters for slugs, improving compatibility with routing and metadata generation.
  - Enhances reliability across static and dynamic rendering paths without altering page content or layout.

- Chores
  - Aligned parameter handling with framework expectations to reduce edge-case issues and future-proof routing behavior.
  - No user-facing changes; users should experience consistent page loading and metadata rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->