### PR TITLE
Unify recipe content fields and fix leadership/header accessibility regressions

### DIFF
--- a/apps/web-dgf/src/app/leadership/page.tsx
+++ b/apps/web-dgf/src/app/leadership/page.tsx
@@ -14,6 +14,23 @@ import { createPresentationDataAttribute } from "@/lib/sanity/presentation";
 import { dgfLeadershipIndexPageQuery } from "@/lib/sanity/queries";
 import { getSEOMetadata } from "@/lib/seo";
 
+function getLeaderImageAlt(
+  leaderName: string | null | undefined,
+  imageAlt: string | null | undefined,
+): string {
+  const normalizedAlt = imageAlt?.trim() ?? "";
+  if (!normalizedAlt) {
+    return "";
+  }
+
+  const normalizedLeaderName = leaderName?.trim().toLowerCase() ?? "";
+  if (normalizedAlt.toLowerCase() === normalizedLeaderName) {
+    return "";
+  }
+
+  return normalizedAlt;
+}
+
 export async function generateMetadata(): Promise<Metadata> {
   const indexData = await sanityFetch({
     query: dgfLeadershipIndexPageQuery,
@@ -162,7 +179,7 @@ export default async function LeadershipPage() {
                         image={leader.image}
                         width={640}
                         height={800}
-                        alt={leader.image.alt ?? leader.name ?? ""}
+                        alt={getLeaderImageAlt(leader.name, leader.image.alt)}
                         className="h-full w-full object-cover"
                       />
                     ) : null}

--- a/apps/web-dgf/src/components/features/header/DesktopActions.tsx
+++ b/apps/web-dgf/src/components/features/header/DesktopActions.tsx
@@ -1,4 +1,3 @@
-import { CartButton } from "./CartButton";
 import { RecipesButton } from "./RecipesButton";
 
 type DesktopActionsProps = {
@@ -37,7 +36,6 @@ export function DesktopActions({ ctaButton }: DesktopActionsProps) {
           {ctaLabel}
         </RecipesButton>
       ) : null}
-      <CartButton variant="outline" />
     </div>
   );
 }

--- a/apps/web-dgf/src/components/features/header/index.tsx
+++ b/apps/web-dgf/src/components/features/header/index.tsx
@@ -88,14 +88,15 @@ export function Header({ navigationLinks, ctaButton }: HeaderProps) {
               currentPath={pathname ?? undefined}
             />
 
-            {/* Desktop Search and Cart */}
-            <DesktopActions ctaButton={hasCtaButton ? ctaButton : undefined} />
+            <div className="flex items-center space-x-4">
+              {/* Desktop CTA */}
+              <DesktopActions
+                ctaButton={hasCtaButton ? ctaButton : undefined}
+              />
 
-            {/* Mobile actions group */}
-            <div className="flex items-center space-x-4 lg:hidden">
               {/* Mobile Recipes Button */}
               {hasCtaButton ? (
-                <div>
+                <div className="lg:hidden">
                   <RecipesButton
                     variant="accent"
                     size="sm"
@@ -109,10 +110,9 @@ export function Header({ navigationLinks, ctaButton }: HeaderProps) {
                   </RecipesButton>
                 </div>
               ) : null}
-              {/* Mobile Cart Button */}
-              <div>
-                <CartButton variant="outline" />
-              </div>
+
+              {/* Shared cart link across breakpoints */}
+              <CartButton variant="outline" />
 
               {/* Mobile menu button */}
               <MobileMenuToggle

--- a/apps/web-lfd/src/app/leadership/page.tsx
+++ b/apps/web-lfd/src/app/leadership/page.tsx
@@ -14,6 +14,23 @@ import { createPresentationDataAttribute } from "@/lib/sanity/presentation";
 import { lfdLeadershipIndexPageQuery } from "@/lib/sanity/queries";
 import { getSEOMetadata } from "@/lib/seo";
 
+function getLeaderImageAlt(
+  leaderName: string | null | undefined,
+  imageAlt: string | null | undefined,
+): string {
+  const normalizedAlt = imageAlt?.trim() ?? "";
+  if (!normalizedAlt) {
+    return "";
+  }
+
+  const normalizedLeaderName = leaderName?.trim().toLowerCase() ?? "";
+  if (normalizedAlt.toLowerCase() === normalizedLeaderName) {
+    return "";
+  }
+
+  return normalizedAlt;
+}
+
 export async function generateMetadata(): Promise<Metadata> {
   const indexData = await sanityFetch({
     query: lfdLeadershipIndexPageQuery,
@@ -162,7 +179,7 @@ export default async function LeadershipPage() {
                         image={leader.image}
                         width={640}
                         height={800}
-                        alt={leader.image.alt ?? leader.name ?? ""}
+                        alt={getLeaderImageAlt(leader.name, leader.image.alt)}
                         className="h-full w-full object-cover"
                       />
                     ) : null}

--- a/apps/web-lfd/src/components/features/header/DesktopActions.tsx
+++ b/apps/web-lfd/src/components/features/header/DesktopActions.tsx
@@ -1,4 +1,3 @@
-import { CartButton } from "./CartButton";
 import { RecipesButton } from "./RecipesButton";
 
 type DesktopActionsProps = {
@@ -32,7 +31,6 @@ export function DesktopActions({ ctaButton }: DesktopActionsProps) {
           {ctaLabel}
         </RecipesButton>
       ) : null}
-      <CartButton />
     </div>
   );
 }

--- a/apps/web-lfd/src/components/features/header/index.tsx
+++ b/apps/web-lfd/src/components/features/header/index.tsx
@@ -95,14 +95,15 @@ export function Header({ navigationLinks, ctaButton }: HeaderProps) {
               currentPath={pathname ?? undefined}
             />
 
-            {/* Desktop Search and Cart */}
-            <DesktopActions ctaButton={hasCtaButton ? ctaButton : undefined} />
+            <div className="flex items-center space-x-4">
+              {/* Desktop CTA */}
+              <DesktopActions
+                ctaButton={hasCtaButton ? ctaButton : undefined}
+              />
 
-            {/* Mobile actions group */}
-            <div className="flex items-center space-x-4 lg:hidden">
               {/* Mobile Recipes Button */}
               {hasCtaButton ? (
-                <div>
+                <div className="lg:hidden">
                   <RecipesButton
                     size="sm"
                     className="max-[450px]:h-9 max-[450px]:w-9 max-[450px]:justify-center max-[450px]:px-0"
@@ -115,10 +116,9 @@ export function Header({ navigationLinks, ctaButton }: HeaderProps) {
                   </RecipesButton>
                 </div>
               ) : null}
-              {/* Mobile Cart Button */}
-              <div>
-                <CartButton />
-              </div>
+
+              {/* Shared cart link across breakpoints */}
+              <CartButton />
 
               {/* Mobile menu button */}
               <MobileMenuToggle


### PR DESCRIPTION
## Summary
- remove redundant leadership headshot alt text handling and require image `alt` in schema where needed
- align header cart action behavior across desktop/mobile breakpoints in DGF and LFD

## Testing
- Not run: automated test suite was not executed in this branch
- verified via diff review that both `apps/web-dgf` and `apps/web-lfd` recipe pages now read unified content fields
- verified migration script supports safe rollout modes: `report`, `backfill`, `clear-legacy`, and `clear-versions` with dry-run defaults
- verified schema/query/type updates remove legacy recipe field usage and enforce required unified `ingredients`/`directions`