### PR TITLE
Fix duplicate wording in sauce image alt text template

### DIFF
--- a/packages/sanity-schema/src/schemaTypes/documents/sauce.ts
+++ b/packages/sanity-schema/src/schemaTypes/documents/sauce.ts
@@ -138,7 +138,7 @@ export const sauce = defineType({
           components: { input: AltTextFromField },
           options: {
             sourceField: "name",
-            template: "a jar of DelGrosso's ${value} sauce",
+            template: "a jar of DelGrosso's ${value}",
           } as StringOptions & AltTextFromFieldOptions,
         }),
       ],


### PR DESCRIPTION
## Summary
- Update sauce document schema alt text template to remove redundant word "sauce".
- Change template from `a jar of DelGrosso's ${value} sauce` to `a jar of DelGrosso's ${value}`.
- Keeps auto-generated alt text cleaner for sauce images.

## Testing
- Not run (schema string/template change only).
- Verified diff updates only `packages/sanity-schema/src/schemaTypes/documents/sauce.ts` with a single-line template change.