### PR TITLE
Add server-side contact submission reference IDs for DGF and LFD

### DIFF
--- a/apps/web-dgf/src/app/api/contact-submit/route.ts
+++ b/apps/web-dgf/src/app/api/contact-submit/route.ts
@@ -1,0 +1,86 @@
+import {
+  buildFormsparkPayload,
+  CONTACT_SUBMISSION_VALIDATION_MESSAGES,
+  generateReferenceId,
+  normalizeContactFormPayload,
+} from "@/lib/contact-submission";
+
+export const runtime = "nodejs";
+
+const FORMSPARK_URL =
+  process.env.FORMSPARK_URL ?? process.env.NEXT_PUBLIC_FORMSPARK_URL;
+const SUBJECT_LABEL = "DelGrosso Foods Contact Submission";
+
+export async function POST(request: Request): Promise<Response> {
+  if (!FORMSPARK_URL) {
+    return Response.json(
+      {
+        ok: false,
+        message: "Form service is not configured.",
+      },
+      { status: 500 },
+    );
+  }
+
+  try {
+    const body = await request.json();
+    const payload = normalizeContactFormPayload(body);
+    const referenceId = generateReferenceId();
+    const formsparkResponse = await fetch(FORMSPARK_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(
+        buildFormsparkPayload(payload, referenceId, SUBJECT_LABEL),
+      ),
+      cache: "no-store",
+    });
+
+    if (!formsparkResponse.ok) {
+      console.error("Formspark submission failed", {
+        status: formsparkResponse.status,
+        statusText: formsparkResponse.statusText,
+      });
+
+      return Response.json(
+        {
+          ok: false,
+          message:
+            "Sorry, there was an error sending your message. Please try again.",
+        },
+        { status: 502 },
+      );
+    }
+
+    return Response.json({
+      ok: true,
+      referenceId,
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "Sorry, there was an error sending your message. Please try again.";
+
+    const status = CONTACT_SUBMISSION_VALIDATION_MESSAGES.has(message)
+      ? 400
+      : 500;
+
+    if (status === 500) {
+      console.error("Contact submission route failed", error);
+    }
+
+    return Response.json(
+      {
+        ok: false,
+        message:
+          status === 400
+            ? message
+            : "Sorry, there was an error sending your message. Please try again.",
+      },
+      { status },
+    );
+  }
+}

--- a/apps/web-dgf/src/components/page-sections/contact-page/contact-form.tsx
+++ b/apps/web-dgf/src/components/page-sections/contact-page/contact-form.tsx
@@ -14,29 +14,17 @@ import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 
 import { announce } from "@/lib/a11y/announce";
-
-const FORMSPARK_URL = process.env.NEXT_PUBLIC_FORMSPARK_URL;
+import type {
+  ContactFormPayload,
+  ContactSubmissionResponse,
+} from "@/lib/contact-submission";
 
 type FormState = "idle" | "submitting" | "success" | "error";
-
-interface ContactFormData {
-  firstName: string;
-  lastName: string;
-  email: string;
-  phone?: string;
-  addressLine1?: string;
-  city?: string;
-  zip?: string;
-  state?: string;
-  howDidYouHearAboutUs?: "" | "store" | "word-of-mouth" | "media-ad" | "other";
-  nameOfSupermarket?: string;
-  otherReferralDetail?: string;
-  brand: "la-famiglia" | "delgrosso-foods" | "organic" | "";
-  message: string;
-}
+const CONTACT_SUBMIT_ENDPOINT = "/api/contact-submit";
 
 export function ContactForm() {
   const [formState, setFormState] = useState<FormState>("idle");
+  const [referenceId, setReferenceId] = useState<string | null>(null);
 
   const {
     register,
@@ -47,7 +35,7 @@ export function ContactForm() {
     reset,
     setValue,
     watch,
-  } = useForm<ContactFormData>({
+  } = useForm<ContactFormPayload>({
     mode: "onChange",
     defaultValues: {
       firstName: "",
@@ -81,15 +69,12 @@ export function ContactForm() {
     }
   }, [clearErrors, setValue, watchedReferralSource]);
 
-  const onSubmit = async (data: ContactFormData) => {
+  const onSubmit = async (data: ContactFormPayload) => {
     setFormState("submitting");
-
-    if (!FORMSPARK_URL) {
-      throw new Error("Form service not configured");
-    }
+    setReferenceId(null);
 
     try {
-      const response = await fetch(FORMSPARK_URL, {
+      const response = await fetch(CONTACT_SUBMIT_ENDPOINT, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -98,11 +83,18 @@ export function ContactForm() {
         body: JSON.stringify(data),
       });
 
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
+      const result = (await response.json()) as ContactSubmissionResponse;
+
+      if (!response.ok || !result.ok) {
+        throw new Error(
+          result.ok
+            ? "Sorry, there was an error sending your message. Please try again."
+            : result.message,
+        );
       }
 
       setFormState("success");
+      setReferenceId(result.referenceId);
       reset();
       announce(
         "Thank you for your message! We'll get back to you soon.",
@@ -562,6 +554,7 @@ export function ContactForm() {
               <p className="text-green-800 text-sm">
                 Thank you for your message! We&apos;ll get back to you within
                 24-48 hours.
+                {referenceId ? ` Reference ID: ${referenceId}.` : ""}
               </p>
             </div>
           </div>

--- a/apps/web-dgf/src/components/page-sections/contact-page/contact-form.tsx
+++ b/apps/web-dgf/src/components/page-sections/contact-page/contact-form.tsx
@@ -10,7 +10,7 @@ import dgfLogo from "@workspace/ui/src/images/logo_0001_dgf.png";
 import lfdLogo from "@workspace/ui/src/images/logo_0002_lfd-family-photo.png";
 import { CheckCircle, LoaderCircle } from "lucide-react";
 import Image from "next/image";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 
 import { announce } from "@/lib/a11y/announce";
@@ -24,6 +24,13 @@ interface ContactFormData {
   lastName: string;
   email: string;
   phone?: string;
+  addressLine1?: string;
+  city?: string;
+  zip?: string;
+  state?: string;
+  howDidYouHearAboutUs?: "" | "store" | "word-of-mouth" | "media-ad" | "other";
+  nameOfSupermarket?: string;
+  otherReferralDetail?: string;
   brand: "la-famiglia" | "delgrosso-foods" | "organic" | "";
   message: string;
 }
@@ -36,6 +43,7 @@ export function ContactForm() {
     handleSubmit,
     formState: { errors, isSubmitting },
     setError,
+    clearErrors,
     reset,
     setValue,
     watch,
@@ -46,12 +54,32 @@ export function ContactForm() {
       lastName: "",
       email: "",
       phone: "",
+      addressLine1: "",
+      city: "",
+      zip: "",
+      state: "",
+      howDidYouHearAboutUs: "",
+      nameOfSupermarket: "",
+      otherReferralDetail: "",
       brand: "",
       message: "",
     },
   });
 
   const watchedBrand = watch("brand");
+  const watchedReferralSource = watch("howDidYouHearAboutUs");
+
+  useEffect(() => {
+    if (watchedReferralSource !== "store") {
+      setValue("nameOfSupermarket", "");
+      clearErrors("nameOfSupermarket");
+    }
+
+    if (watchedReferralSource !== "other") {
+      setValue("otherReferralDetail", "");
+      clearErrors("otherReferralDetail");
+    }
+  }, [clearErrors, setValue, watchedReferralSource]);
 
   const onSubmit = async (data: ContactFormData) => {
     setFormState("submitting");
@@ -207,6 +235,168 @@ export function ContactForm() {
               disabled={isSubmitting}
             />
           </div>
+
+          <div className="space-y-4">
+            <fieldset className="space-y-4">
+              <legend className="block text-sm font-medium text-foreground">
+                Address
+              </legend>
+              <div>
+                <label
+                  htmlFor="address-line-1"
+                  className="block text-sm font-medium text-foreground mb-2"
+                >
+                  Address Line 1
+                </label>
+                <input
+                  type="text"
+                  id="address-line-1"
+                  {...register("addressLine1")}
+                  className="w-full rounded-md border border-input bg-background px-3.5 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                  placeholder="123 Main St"
+                  disabled={isSubmitting}
+                />
+              </div>
+
+              <div className="grid grid-cols-1 gap-x-8 gap-y-6 sm:grid-cols-3">
+                <div>
+                  <label
+                    htmlFor="contact-city"
+                    className="block text-sm font-medium text-foreground mb-2"
+                  >
+                    City
+                  </label>
+                  <input
+                    type="text"
+                    id="contact-city"
+                    {...register("city")}
+                    className="w-full rounded-md border border-input bg-background px-3.5 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                    placeholder="Tipton"
+                    disabled={isSubmitting}
+                  />
+                </div>
+
+                <div>
+                  <label
+                    htmlFor="contact-zip"
+                    className="block text-sm font-medium text-foreground mb-2"
+                  >
+                    Zip
+                  </label>
+                  <input
+                    type="text"
+                    id="contact-zip"
+                    {...register("zip")}
+                    className="w-full rounded-md border border-input bg-background px-3.5 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                    placeholder="16684"
+                    disabled={isSubmitting}
+                  />
+                </div>
+
+                <div>
+                  <label
+                    htmlFor="contact-state"
+                    className="block text-sm font-medium text-foreground mb-2"
+                  >
+                    State
+                  </label>
+                  <input
+                    type="text"
+                    id="contact-state"
+                    {...register("state")}
+                    className="w-full rounded-md border border-input bg-background px-3.5 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                    placeholder="PA"
+                    disabled={isSubmitting}
+                  />
+                </div>
+              </div>
+            </fieldset>
+          </div>
+
+          <div>
+            <label
+              htmlFor="hear-about-us"
+              className="block text-sm font-medium text-foreground mb-2"
+            >
+              How did you hear about us
+            </label>
+            <select
+              id="hear-about-us"
+              {...register("howDidYouHearAboutUs")}
+              className="w-full rounded-md border border-input bg-background px-3.5 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={isSubmitting}
+            >
+              <option value="">Select an option</option>
+              <option value="store">Discovered product in a store</option>
+              <option value="word-of-mouth">Word of mouth</option>
+              <option value="media-ad">
+                Saw a TV show/Magazine article/Ad that featured DelGrosso
+              </option>
+              <option value="other">Other</option>
+            </select>
+          </div>
+
+          {watchedReferralSource === "store" && (
+            <div>
+              <label
+                htmlFor="supermarket-name"
+                className="block text-sm font-medium text-foreground mb-2"
+              >
+                Name of Supermarket *
+              </label>
+              <input
+                type="text"
+                id="supermarket-name"
+                {...register("nameOfSupermarket", {
+                  validate: (value) =>
+                    watchedReferralSource !== "store" ||
+                    value?.trim() ||
+                    "Name of Supermarket is required",
+                })}
+                className={`w-full rounded-md border bg-background px-3.5 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${
+                  errors.nameOfSupermarket ? "border-red-500" : "border-input"
+                }`}
+                placeholder="Enter the store name"
+                disabled={isSubmitting}
+              />
+              {errors.nameOfSupermarket && (
+                <p className="mt-1 text-sm text-red-600">
+                  {errors.nameOfSupermarket.message}
+                </p>
+              )}
+            </div>
+          )}
+
+          {watchedReferralSource === "other" && (
+            <div>
+              <label
+                htmlFor="referral-detail"
+                className="block text-sm font-medium text-foreground mb-2"
+              >
+                Please tell us how you heard about us *
+              </label>
+              <input
+                type="text"
+                id="referral-detail"
+                {...register("otherReferralDetail", {
+                  validate: (value) =>
+                    watchedReferralSource !== "other" ||
+                    value?.trim() ||
+                    "Please tell us how you heard about us",
+                })}
+                className={`w-full rounded-md border bg-background px-3.5 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${
+                  errors.otherReferralDetail ? "border-red-500" : "border-input"
+                }`}
+                placeholder="Enter your answer"
+                disabled={isSubmitting}
+              />
+              {errors.otherReferralDetail && (
+                <p className="mt-1 text-sm text-red-600">
+                  {errors.otherReferralDetail.message}
+                </p>
+              )}
+            </div>
+          )}
         </div>
 
         {/* Brand Selection Section */}

--- a/apps/web-dgf/src/components/page-sections/contact-page/contact-form.tsx
+++ b/apps/web-dgf/src/components/page-sections/contact-page/contact-form.tsx
@@ -342,7 +342,7 @@ export function ContactForm() {
                 {...register("nameOfSupermarket", {
                   validate: (value) =>
                     watchedReferralSource !== "store" ||
-                    value?.trim() ||
+                    Boolean(value?.trim()) ||
                     "Name of Supermarket is required",
                 })}
                 className={`w-full rounded-md border bg-background px-3.5 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${
@@ -373,7 +373,7 @@ export function ContactForm() {
                 {...register("otherReferralDetail", {
                   validate: (value) =>
                     watchedReferralSource !== "other" ||
-                    value?.trim() ||
+                    Boolean(value?.trim()) ||
                     "Please tell us how you heard about us",
                 })}
                 className={`w-full rounded-md border bg-background px-3.5 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${

--- a/apps/web-dgf/src/lib/contact-submission.ts
+++ b/apps/web-dgf/src/lib/contact-submission.ts
@@ -1,0 +1,171 @@
+import { randomBytes } from "node:crypto";
+
+const CROCKFORD_BASE32_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+const REFERENCE_ID_LENGTH = 8;
+
+export type ContactFormPayload = {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone?: string;
+  addressLine1?: string;
+  city?: string;
+  zip?: string;
+  state?: string;
+  howDidYouHearAboutUs?: "" | "store" | "word-of-mouth" | "media-ad" | "other";
+  nameOfSupermarket?: string;
+  otherReferralDetail?: string;
+  brand: "la-famiglia" | "delgrosso-foods" | "organic" | "";
+  message: string;
+};
+
+export type ContactSubmissionSuccess = {
+  ok: true;
+  referenceId: string;
+};
+
+export type ContactSubmissionFailure = {
+  ok: false;
+  message: string;
+};
+
+export type ContactSubmissionResponse =
+  | ContactSubmissionSuccess
+  | ContactSubmissionFailure;
+
+export const CONTACT_SUBMISSION_VALIDATION_MESSAGES = new Set([
+  "Invalid form submission",
+  "First name is required",
+  "Last name is required",
+  "Email is required",
+  "Please enter a valid email address",
+  "Please select a brand",
+  "Message is required",
+  "Message must be at least 10 characters",
+  "Name of Supermarket is required",
+  "Please tell us how you heard about us",
+]);
+
+type CleanContactFormPayload = {
+  [K in keyof ContactFormPayload]: string;
+};
+
+function cleanOptional(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function requireNonEmptyString(value: unknown, fieldName: string): string {
+  const cleaned = cleanOptional(value);
+  if (!cleaned) {
+    throw new Error(`${fieldName} is required`);
+  }
+  return cleaned;
+}
+
+function normalizeEmail(value: unknown): string {
+  const email = requireNonEmptyString(value, "Email").toLowerCase();
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/i.test(email)) {
+    throw new Error("Please enter a valid email address");
+  }
+  return email;
+}
+
+function normalizeBrand(value: unknown): ContactFormPayload["brand"] {
+  if (
+    value === "la-famiglia" ||
+    value === "delgrosso-foods" ||
+    value === "organic"
+  ) {
+    return value;
+  }
+  throw new Error("Please select a brand");
+}
+
+function normalizeReferralSource(
+  value: unknown,
+): ContactFormPayload["howDidYouHearAboutUs"] {
+  if (
+    value === "" ||
+    value === "store" ||
+    value === "word-of-mouth" ||
+    value === "media-ad" ||
+    value === "other"
+  ) {
+    return value;
+  }
+  return "";
+}
+
+export function normalizeContactFormPayload(
+  input: unknown,
+): CleanContactFormPayload {
+  if (!input || typeof input !== "object") {
+    throw new Error("Invalid form submission");
+  }
+
+  const data = input as Record<string, unknown>;
+  const referralSource = normalizeReferralSource(data.howDidYouHearAboutUs);
+  const cleaned: CleanContactFormPayload = {
+    firstName: requireNonEmptyString(data.firstName, "First name"),
+    lastName: requireNonEmptyString(data.lastName, "Last name"),
+    email: normalizeEmail(data.email),
+    phone: cleanOptional(data.phone),
+    addressLine1: cleanOptional(data.addressLine1),
+    city: cleanOptional(data.city),
+    zip: cleanOptional(data.zip),
+    state: cleanOptional(data.state),
+    howDidYouHearAboutUs: referralSource,
+    nameOfSupermarket: cleanOptional(data.nameOfSupermarket),
+    otherReferralDetail: cleanOptional(data.otherReferralDetail),
+    brand: normalizeBrand(data.brand),
+    message: requireNonEmptyString(data.message, "Message"),
+  };
+
+  if (cleaned.message.length < 10) {
+    throw new Error("Message must be at least 10 characters");
+  }
+
+  if (referralSource === "store" && !cleaned.nameOfSupermarket) {
+    throw new Error("Name of Supermarket is required");
+  }
+
+  if (referralSource === "other" && !cleaned.otherReferralDetail) {
+    throw new Error("Please tell us how you heard about us");
+  }
+
+  if (referralSource !== "store") {
+    cleaned.nameOfSupermarket = "";
+  }
+
+  if (referralSource !== "other") {
+    cleaned.otherReferralDetail = "";
+  }
+
+  return cleaned;
+}
+
+export function generateReferenceId(): string {
+  const bytes = randomBytes(REFERENCE_ID_LENGTH);
+  let output = "";
+
+  for (const byte of bytes) {
+    output +=
+      CROCKFORD_BASE32_ALPHABET[byte % CROCKFORD_BASE32_ALPHABET.length];
+  }
+
+  return output;
+}
+
+export function buildFormsparkPayload(
+  payload: CleanContactFormPayload,
+  referenceId: string,
+  subjectLabel: string,
+) {
+  return {
+    ...payload,
+    referenceId,
+    _email: {
+      subject: `${subjectLabel} [${referenceId}]`,
+    },
+  };
+}

--- a/apps/web-lfd/src/app/api/contact-submit/route.ts
+++ b/apps/web-lfd/src/app/api/contact-submit/route.ts
@@ -1,0 +1,86 @@
+import {
+  buildFormsparkPayload,
+  CONTACT_SUBMISSION_VALIDATION_MESSAGES,
+  generateReferenceId,
+  normalizeContactFormPayload,
+} from "@/lib/contact-submission";
+
+export const runtime = "nodejs";
+
+const FORMSPARK_URL =
+  process.env.FORMSPARK_URL ?? process.env.NEXT_PUBLIC_FORMSPARK_URL;
+const SUBJECT_LABEL = "La Famiglia DelGrosso Contact Submission";
+
+export async function POST(request: Request): Promise<Response> {
+  if (!FORMSPARK_URL) {
+    return Response.json(
+      {
+        ok: false,
+        message: "Form service is not configured.",
+      },
+      { status: 500 },
+    );
+  }
+
+  try {
+    const body = await request.json();
+    const payload = normalizeContactFormPayload(body);
+    const referenceId = generateReferenceId();
+    const formsparkResponse = await fetch(FORMSPARK_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(
+        buildFormsparkPayload(payload, referenceId, SUBJECT_LABEL),
+      ),
+      cache: "no-store",
+    });
+
+    if (!formsparkResponse.ok) {
+      console.error("Formspark submission failed", {
+        status: formsparkResponse.status,
+        statusText: formsparkResponse.statusText,
+      });
+
+      return Response.json(
+        {
+          ok: false,
+          message:
+            "Sorry, there was an error sending your message. Please try again.",
+        },
+        { status: 502 },
+      );
+    }
+
+    return Response.json({
+      ok: true,
+      referenceId,
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "Sorry, there was an error sending your message. Please try again.";
+
+    const status = CONTACT_SUBMISSION_VALIDATION_MESSAGES.has(message)
+      ? 400
+      : 500;
+
+    if (status === 500) {
+      console.error("Contact submission route failed", error);
+    }
+
+    return Response.json(
+      {
+        ok: false,
+        message:
+          status === 400
+            ? message
+            : "Sorry, there was an error sending your message. Please try again.",
+      },
+      { status },
+    );
+  }
+}

--- a/apps/web-lfd/src/components/page-sections/contact-page/contact-form.tsx
+++ b/apps/web-lfd/src/components/page-sections/contact-page/contact-form.tsx
@@ -14,29 +14,17 @@ import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 
 import { announce } from "@/lib/a11y/announce";
-
-const FORMSPARK_URL = process.env.NEXT_PUBLIC_FORMSPARK_URL;
+import type {
+  ContactFormPayload,
+  ContactSubmissionResponse,
+} from "@/lib/contact-submission";
 
 type FormState = "idle" | "submitting" | "success" | "error";
-
-interface ContactFormData {
-  firstName: string;
-  lastName: string;
-  email: string;
-  phone?: string;
-  addressLine1?: string;
-  city?: string;
-  zip?: string;
-  state?: string;
-  howDidYouHearAboutUs?: "" | "store" | "word-of-mouth" | "media-ad" | "other";
-  nameOfSupermarket?: string;
-  otherReferralDetail?: string;
-  brand: "la-famiglia" | "delgrosso-foods" | "organic" | "";
-  message: string;
-}
+const CONTACT_SUBMIT_ENDPOINT = "/api/contact-submit";
 
 export function ContactForm() {
   const [formState, setFormState] = useState<FormState>("idle");
+  const [referenceId, setReferenceId] = useState<string | null>(null);
 
   const {
     register,
@@ -47,7 +35,7 @@ export function ContactForm() {
     reset,
     setValue,
     watch,
-  } = useForm<ContactFormData>({
+  } = useForm<ContactFormPayload>({
     mode: "onChange",
     defaultValues: {
       firstName: "",
@@ -81,15 +69,12 @@ export function ContactForm() {
     }
   }, [clearErrors, setValue, watchedReferralSource]);
 
-  const onSubmit = async (data: ContactFormData) => {
+  const onSubmit = async (data: ContactFormPayload) => {
     setFormState("submitting");
-
-    if (!FORMSPARK_URL) {
-      throw new Error("Form service not configured");
-    }
+    setReferenceId(null);
 
     try {
-      const response = await fetch(FORMSPARK_URL, {
+      const response = await fetch(CONTACT_SUBMIT_ENDPOINT, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -98,11 +83,18 @@ export function ContactForm() {
         body: JSON.stringify(data),
       });
 
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
+      const result = (await response.json()) as ContactSubmissionResponse;
+
+      if (!response.ok || !result.ok) {
+        throw new Error(
+          result.ok
+            ? "Sorry, there was an error sending your message. Please try again."
+            : result.message,
+        );
       }
 
       setFormState("success");
+      setReferenceId(result.referenceId);
       reset();
       announce(
         "Thank you for your message! We'll get back to you soon.",
@@ -562,6 +554,7 @@ export function ContactForm() {
               <p className="text-green-800 text-sm">
                 Thank you for your message! We&apos;ll get back to you within
                 24-48 hours.
+                {referenceId ? ` Reference ID: ${referenceId}.` : ""}
               </p>
             </div>
           </div>

--- a/apps/web-lfd/src/components/page-sections/contact-page/contact-form.tsx
+++ b/apps/web-lfd/src/components/page-sections/contact-page/contact-form.tsx
@@ -10,7 +10,7 @@ import dgfLogo from "@workspace/ui/src/images/logo_0001_dgf.png";
 import lfdLogo from "@workspace/ui/src/images/logo_0002_lfd-family-photo.png";
 import { CheckCircle, LoaderCircle } from "lucide-react";
 import Image from "next/image";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 
 import { announce } from "@/lib/a11y/announce";
@@ -24,6 +24,13 @@ interface ContactFormData {
   lastName: string;
   email: string;
   phone?: string;
+  addressLine1?: string;
+  city?: string;
+  zip?: string;
+  state?: string;
+  howDidYouHearAboutUs?: "" | "store" | "word-of-mouth" | "media-ad" | "other";
+  nameOfSupermarket?: string;
+  otherReferralDetail?: string;
   brand: "la-famiglia" | "delgrosso-foods" | "organic" | "";
   message: string;
 }
@@ -36,6 +43,7 @@ export function ContactForm() {
     handleSubmit,
     formState: { errors, isSubmitting },
     setError,
+    clearErrors,
     reset,
     setValue,
     watch,
@@ -46,12 +54,32 @@ export function ContactForm() {
       lastName: "",
       email: "",
       phone: "",
+      addressLine1: "",
+      city: "",
+      zip: "",
+      state: "",
+      howDidYouHearAboutUs: "",
+      nameOfSupermarket: "",
+      otherReferralDetail: "",
       brand: "",
       message: "",
     },
   });
 
   const watchedBrand = watch("brand");
+  const watchedReferralSource = watch("howDidYouHearAboutUs");
+
+  useEffect(() => {
+    if (watchedReferralSource !== "store") {
+      setValue("nameOfSupermarket", "");
+      clearErrors("nameOfSupermarket");
+    }
+
+    if (watchedReferralSource !== "other") {
+      setValue("otherReferralDetail", "");
+      clearErrors("otherReferralDetail");
+    }
+  }, [clearErrors, setValue, watchedReferralSource]);
 
   const onSubmit = async (data: ContactFormData) => {
     setFormState("submitting");
@@ -207,6 +235,168 @@ export function ContactForm() {
               disabled={isSubmitting}
             />
           </div>
+
+          <div className="space-y-4">
+            <fieldset className="space-y-4">
+              <legend className="block text-sm font-medium text-foreground">
+                Address
+              </legend>
+              <div>
+                <label
+                  htmlFor="address-line-1"
+                  className="block text-sm font-medium text-foreground mb-2"
+                >
+                  Address Line 1
+                </label>
+                <input
+                  type="text"
+                  id="address-line-1"
+                  {...register("addressLine1")}
+                  className="w-full rounded-md border border-input bg-background px-3.5 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                  placeholder="123 Main St"
+                  disabled={isSubmitting}
+                />
+              </div>
+
+              <div className="grid grid-cols-1 gap-x-8 gap-y-6 sm:grid-cols-3">
+                <div>
+                  <label
+                    htmlFor="contact-city"
+                    className="block text-sm font-medium text-foreground mb-2"
+                  >
+                    City
+                  </label>
+                  <input
+                    type="text"
+                    id="contact-city"
+                    {...register("city")}
+                    className="w-full rounded-md border border-input bg-background px-3.5 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                    placeholder="Tipton"
+                    disabled={isSubmitting}
+                  />
+                </div>
+
+                <div>
+                  <label
+                    htmlFor="contact-zip"
+                    className="block text-sm font-medium text-foreground mb-2"
+                  >
+                    Zip
+                  </label>
+                  <input
+                    type="text"
+                    id="contact-zip"
+                    {...register("zip")}
+                    className="w-full rounded-md border border-input bg-background px-3.5 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                    placeholder="16684"
+                    disabled={isSubmitting}
+                  />
+                </div>
+
+                <div>
+                  <label
+                    htmlFor="contact-state"
+                    className="block text-sm font-medium text-foreground mb-2"
+                  >
+                    State
+                  </label>
+                  <input
+                    type="text"
+                    id="contact-state"
+                    {...register("state")}
+                    className="w-full rounded-md border border-input bg-background px-3.5 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                    placeholder="PA"
+                    disabled={isSubmitting}
+                  />
+                </div>
+              </div>
+            </fieldset>
+          </div>
+
+          <div>
+            <label
+              htmlFor="hear-about-us"
+              className="block text-sm font-medium text-foreground mb-2"
+            >
+              How did you hear about us
+            </label>
+            <select
+              id="hear-about-us"
+              {...register("howDidYouHearAboutUs")}
+              className="w-full rounded-md border border-input bg-background px-3.5 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={isSubmitting}
+            >
+              <option value="">Select an option</option>
+              <option value="store">Discovered product in a store</option>
+              <option value="word-of-mouth">Word of mouth</option>
+              <option value="media-ad">
+                Saw a TV show/Magazine article/Ad that featured DelGrosso
+              </option>
+              <option value="other">Other</option>
+            </select>
+          </div>
+
+          {watchedReferralSource === "store" && (
+            <div>
+              <label
+                htmlFor="supermarket-name"
+                className="block text-sm font-medium text-foreground mb-2"
+              >
+                Name of Supermarket *
+              </label>
+              <input
+                type="text"
+                id="supermarket-name"
+                {...register("nameOfSupermarket", {
+                  validate: (value) =>
+                    watchedReferralSource !== "store" ||
+                    value?.trim() ||
+                    "Name of Supermarket is required",
+                })}
+                className={`w-full rounded-md border bg-background px-3.5 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${
+                  errors.nameOfSupermarket ? "border-red-500" : "border-input"
+                }`}
+                placeholder="Enter the store name"
+                disabled={isSubmitting}
+              />
+              {errors.nameOfSupermarket && (
+                <p className="mt-1 text-sm text-red-600">
+                  {errors.nameOfSupermarket.message}
+                </p>
+              )}
+            </div>
+          )}
+
+          {watchedReferralSource === "other" && (
+            <div>
+              <label
+                htmlFor="referral-detail"
+                className="block text-sm font-medium text-foreground mb-2"
+              >
+                Please tell us how you heard about us *
+              </label>
+              <input
+                type="text"
+                id="referral-detail"
+                {...register("otherReferralDetail", {
+                  validate: (value) =>
+                    watchedReferralSource !== "other" ||
+                    value?.trim() ||
+                    "Please tell us how you heard about us",
+                })}
+                className={`w-full rounded-md border bg-background px-3.5 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${
+                  errors.otherReferralDetail ? "border-red-500" : "border-input"
+                }`}
+                placeholder="Enter your answer"
+                disabled={isSubmitting}
+              />
+              {errors.otherReferralDetail && (
+                <p className="mt-1 text-sm text-red-600">
+                  {errors.otherReferralDetail.message}
+                </p>
+              )}
+            </div>
+          )}
         </div>
 
         {/* Brand Selection Section */}

--- a/apps/web-lfd/src/components/page-sections/contact-page/contact-form.tsx
+++ b/apps/web-lfd/src/components/page-sections/contact-page/contact-form.tsx
@@ -342,7 +342,7 @@ export function ContactForm() {
                 {...register("nameOfSupermarket", {
                   validate: (value) =>
                     watchedReferralSource !== "store" ||
-                    value?.trim() ||
+                    Boolean(value?.trim()) ||
                     "Name of Supermarket is required",
                 })}
                 className={`w-full rounded-md border bg-background px-3.5 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${
@@ -373,7 +373,7 @@ export function ContactForm() {
                 {...register("otherReferralDetail", {
                   validate: (value) =>
                     watchedReferralSource !== "other" ||
-                    value?.trim() ||
+                    Boolean(value?.trim()) ||
                     "Please tell us how you heard about us",
                 })}
                 className={`w-full rounded-md border bg-background px-3.5 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${

--- a/apps/web-lfd/src/lib/contact-submission.ts
+++ b/apps/web-lfd/src/lib/contact-submission.ts
@@ -1,0 +1,171 @@
+import { randomBytes } from "node:crypto";
+
+const CROCKFORD_BASE32_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+const REFERENCE_ID_LENGTH = 8;
+
+export type ContactFormPayload = {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone?: string;
+  addressLine1?: string;
+  city?: string;
+  zip?: string;
+  state?: string;
+  howDidYouHearAboutUs?: "" | "store" | "word-of-mouth" | "media-ad" | "other";
+  nameOfSupermarket?: string;
+  otherReferralDetail?: string;
+  brand: "la-famiglia" | "delgrosso-foods" | "organic" | "";
+  message: string;
+};
+
+export type ContactSubmissionSuccess = {
+  ok: true;
+  referenceId: string;
+};
+
+export type ContactSubmissionFailure = {
+  ok: false;
+  message: string;
+};
+
+export type ContactSubmissionResponse =
+  | ContactSubmissionSuccess
+  | ContactSubmissionFailure;
+
+export const CONTACT_SUBMISSION_VALIDATION_MESSAGES = new Set([
+  "Invalid form submission",
+  "First name is required",
+  "Last name is required",
+  "Email is required",
+  "Please enter a valid email address",
+  "Please select a brand",
+  "Message is required",
+  "Message must be at least 10 characters",
+  "Name of Supermarket is required",
+  "Please tell us how you heard about us",
+]);
+
+type CleanContactFormPayload = {
+  [K in keyof ContactFormPayload]: string;
+};
+
+function cleanOptional(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function requireNonEmptyString(value: unknown, fieldName: string): string {
+  const cleaned = cleanOptional(value);
+  if (!cleaned) {
+    throw new Error(`${fieldName} is required`);
+  }
+  return cleaned;
+}
+
+function normalizeEmail(value: unknown): string {
+  const email = requireNonEmptyString(value, "Email").toLowerCase();
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/i.test(email)) {
+    throw new Error("Please enter a valid email address");
+  }
+  return email;
+}
+
+function normalizeBrand(value: unknown): ContactFormPayload["brand"] {
+  if (
+    value === "la-famiglia" ||
+    value === "delgrosso-foods" ||
+    value === "organic"
+  ) {
+    return value;
+  }
+  throw new Error("Please select a brand");
+}
+
+function normalizeReferralSource(
+  value: unknown,
+): ContactFormPayload["howDidYouHearAboutUs"] {
+  if (
+    value === "" ||
+    value === "store" ||
+    value === "word-of-mouth" ||
+    value === "media-ad" ||
+    value === "other"
+  ) {
+    return value;
+  }
+  return "";
+}
+
+export function normalizeContactFormPayload(
+  input: unknown,
+): CleanContactFormPayload {
+  if (!input || typeof input !== "object") {
+    throw new Error("Invalid form submission");
+  }
+
+  const data = input as Record<string, unknown>;
+  const referralSource = normalizeReferralSource(data.howDidYouHearAboutUs);
+  const cleaned: CleanContactFormPayload = {
+    firstName: requireNonEmptyString(data.firstName, "First name"),
+    lastName: requireNonEmptyString(data.lastName, "Last name"),
+    email: normalizeEmail(data.email),
+    phone: cleanOptional(data.phone),
+    addressLine1: cleanOptional(data.addressLine1),
+    city: cleanOptional(data.city),
+    zip: cleanOptional(data.zip),
+    state: cleanOptional(data.state),
+    howDidYouHearAboutUs: referralSource,
+    nameOfSupermarket: cleanOptional(data.nameOfSupermarket),
+    otherReferralDetail: cleanOptional(data.otherReferralDetail),
+    brand: normalizeBrand(data.brand),
+    message: requireNonEmptyString(data.message, "Message"),
+  };
+
+  if (cleaned.message.length < 10) {
+    throw new Error("Message must be at least 10 characters");
+  }
+
+  if (referralSource === "store" && !cleaned.nameOfSupermarket) {
+    throw new Error("Name of Supermarket is required");
+  }
+
+  if (referralSource === "other" && !cleaned.otherReferralDetail) {
+    throw new Error("Please tell us how you heard about us");
+  }
+
+  if (referralSource !== "store") {
+    cleaned.nameOfSupermarket = "";
+  }
+
+  if (referralSource !== "other") {
+    cleaned.otherReferralDetail = "";
+  }
+
+  return cleaned;
+}
+
+export function generateReferenceId(): string {
+  const bytes = randomBytes(REFERENCE_ID_LENGTH);
+  let output = "";
+
+  for (const byte of bytes) {
+    output +=
+      CROCKFORD_BASE32_ALPHABET[byte % CROCKFORD_BASE32_ALPHABET.length];
+  }
+
+  return output;
+}
+
+export function buildFormsparkPayload(
+  payload: CleanContactFormPayload,
+  referenceId: string,
+  subjectLabel: string,
+) {
+  return {
+    ...payload,
+    referenceId,
+    _email: {
+      subject: `${subjectLabel} [${referenceId}]`,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- route DGF and LFD contact form submissions through internal Next.js API endpoints
- generate an 8-character reference ID on the server and forward it to Formspark
- set the Formspark notification email subject to include the generated reference ID
- show the reference ID in the success state after a successful submission
- centralize contact submission payload normalization and Formspark payload building per app

## Testing
- `pnpm --filter web-dgf typecheck`
- `pnpm --filter web-lfd typecheck`