### PR TITLE
Add dated contact submission IDs for DGF and LFD forms

### DIFF
--- a/apps/web-dgf/src/app/api/contact-submit/route.ts
+++ b/apps/web-dgf/src/app/api/contact-submit/route.ts
@@ -1,0 +1,82 @@
+import {
+  buildFormsparkPayload,
+  CONTACT_SUBMISSION_VALIDATION_MESSAGES,
+  generateReferenceId,
+  normalizeContactFormPayload,
+} from "@/lib/contact-submission";
+
+export const runtime = "nodejs";
+
+const FORMSPARK_URL =
+  process.env.FORMSPARK_URL ?? process.env.NEXT_PUBLIC_FORMSPARK_URL;
+const SUBJECT_LABEL = "DelGrosso Foods Contact Submission";
+const GENERIC_ERROR_MESSAGE =
+  "Sorry, there was an error sending your message. Please try again.";
+
+export async function POST(request: Request): Promise<Response> {
+  if (!FORMSPARK_URL) {
+    return Response.json(
+      {
+        ok: false,
+        message: "Form service is not configured.",
+      },
+      { status: 500 },
+    );
+  }
+
+  try {
+    const body = await request.json();
+    const payload = normalizeContactFormPayload(body);
+    const referenceId = generateReferenceId();
+
+    const formsparkResponse = await fetch(FORMSPARK_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(
+        buildFormsparkPayload(payload, referenceId, SUBJECT_LABEL),
+      ),
+      cache: "no-store",
+    });
+
+    if (!formsparkResponse.ok) {
+      console.error("Formspark submission failed", {
+        status: formsparkResponse.status,
+        statusText: formsparkResponse.statusText,
+      });
+
+      return Response.json(
+        {
+          ok: false,
+          message: GENERIC_ERROR_MESSAGE,
+        },
+        { status: 502 },
+      );
+    }
+
+    return Response.json({
+      ok: true,
+      referenceId,
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : GENERIC_ERROR_MESSAGE;
+    const status = CONTACT_SUBMISSION_VALIDATION_MESSAGES.has(message)
+      ? 400
+      : 500;
+
+    if (status === 500) {
+      console.error("Contact submission route failed", error);
+    }
+
+    return Response.json(
+      {
+        ok: false,
+        message: status === 400 ? message : GENERIC_ERROR_MESSAGE,
+      },
+      { status },
+    );
+  }
+}

--- a/apps/web-dgf/src/components/page-sections/contact-page/contact-form.tsx
+++ b/apps/web-dgf/src/components/page-sections/contact-page/contact-form.tsx
@@ -14,22 +14,19 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 
 import { announce } from "@/lib/a11y/announce";
-
-const FORMSPARK_URL = process.env.NEXT_PUBLIC_FORMSPARK_URL;
+import type {
+  ContactFormPayload,
+  ContactSubmissionResponse,
+} from "@/lib/contact-submission";
 
 type FormState = "idle" | "submitting" | "success" | "error";
-
-interface ContactFormData {
-  firstName: string;
-  lastName: string;
-  email: string;
-  phone?: string;
-  brand: "la-famiglia" | "delgrosso-foods" | "organic" | "";
-  message: string;
-}
+const CONTACT_SUBMIT_ENDPOINT = "/api/contact-submit";
+const GENERIC_ERROR_MESSAGE =
+  "Sorry, there was an error sending your message. Please try again.";
 
 export function ContactForm() {
   const [formState, setFormState] = useState<FormState>("idle");
+  const [referenceId, setReferenceId] = useState<string | null>(null);
 
   const {
     register,
@@ -39,7 +36,7 @@ export function ContactForm() {
     reset,
     setValue,
     watch,
-  } = useForm<ContactFormData>({
+  } = useForm<ContactFormPayload>({
     mode: "onChange",
     defaultValues: {
       firstName: "",
@@ -53,15 +50,12 @@ export function ContactForm() {
 
   const watchedBrand = watch("brand");
 
-  const onSubmit = async (data: ContactFormData) => {
+  const onSubmit = async (data: ContactFormPayload) => {
     setFormState("submitting");
-
-    if (!FORMSPARK_URL) {
-      throw new Error("Form service not configured");
-    }
+    setReferenceId(null);
 
     try {
-      const response = await fetch(FORMSPARK_URL, {
+      const response = await fetch(CONTACT_SUBMIT_ENDPOINT, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -70,11 +64,14 @@ export function ContactForm() {
         body: JSON.stringify(data),
       });
 
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
+      const result = (await response.json()) as ContactSubmissionResponse;
+
+      if (!response.ok || !result.ok) {
+        throw new Error(result.ok ? GENERIC_ERROR_MESSAGE : result.message);
       }
 
       setFormState("success");
+      setReferenceId(result.referenceId);
       reset();
       announce(
         "Thank you for your message! We'll get back to you soon.",
@@ -84,8 +81,7 @@ export function ContactForm() {
       console.error("Form submission error:", error);
       setFormState("error");
       setError("root", {
-        message:
-          "Sorry, there was an error sending your message. Please try again.",
+        message: error instanceof Error ? error.message : GENERIC_ERROR_MESSAGE,
       });
       announce(
         "Sorry, there was an error sending your message. Please try again.",
@@ -372,6 +368,7 @@ export function ContactForm() {
               <p className="text-green-800 text-sm">
                 Thank you for your message! We&apos;ll get back to you within
                 24-48 hours.
+                {referenceId ? ` Reference ID: ${referenceId}.` : ""}
               </p>
             </div>
           </div>

--- a/apps/web-dgf/src/lib/contact-submission.ts
+++ b/apps/web-dgf/src/lib/contact-submission.ts
@@ -1,0 +1,135 @@
+import { randomBytes } from "node:crypto";
+
+const REFERENCE_ID_LETTERS = "ABCDEFGHJKMNPQRSTUVWXYZ";
+const RANDOM_SUFFIX_LENGTH = 4;
+const EASTERN_TIMEZONE = "America/New_York";
+
+export type ContactFormPayload = {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone?: string;
+  brand: "la-famiglia" | "delgrosso-foods" | "organic" | "";
+  message: string;
+};
+
+export type ContactSubmissionResponse =
+  | { ok: true; referenceId: string }
+  | { ok: false; message: string };
+
+export const CONTACT_SUBMISSION_VALIDATION_MESSAGES = new Set([
+  "Invalid form submission",
+  "First name is required",
+  "Last name is required",
+  "Email is required",
+  "Please enter a valid email address including a domain",
+  "Please select a brand",
+  "Message is required",
+  "Message must be at least 10 characters",
+]);
+
+function cleanOptional(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function requireNonEmptyString(value: unknown, fieldName: string): string {
+  const cleaned = cleanOptional(value);
+  if (!cleaned) {
+    throw new Error(`${fieldName} is required`);
+  }
+  return cleaned;
+}
+
+function normalizeEmail(value: unknown): string {
+  const email = requireNonEmptyString(value, "Email");
+  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/i;
+
+  if (!emailPattern.test(email)) {
+    throw new Error("Please enter a valid email address including a domain");
+  }
+
+  return email.toLowerCase();
+}
+
+function normalizeBrand(value: unknown): ContactFormPayload["brand"] {
+  if (
+    value === "la-famiglia" ||
+    value === "delgrosso-foods" ||
+    value === "organic"
+  ) {
+    return value;
+  }
+
+  throw new Error("Please select a brand");
+}
+
+export function normalizeContactFormPayload(
+  input: unknown,
+): ContactFormPayload {
+  if (!input || typeof input !== "object") {
+    throw new Error("Invalid form submission");
+  }
+
+  const data = input as Record<string, unknown>;
+  const message = requireNonEmptyString(data.message, "Message");
+
+  if (message.length < 10) {
+    throw new Error("Message must be at least 10 characters");
+  }
+
+  return {
+    firstName: requireNonEmptyString(data.firstName, "First name"),
+    lastName: requireNonEmptyString(data.lastName, "Last name"),
+    email: normalizeEmail(data.email),
+    phone: cleanOptional(data.phone),
+    brand: normalizeBrand(data.brand),
+    message,
+  };
+}
+
+function getDatePrefix(now: Date): string {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: EASTERN_TIMEZONE,
+    year: "2-digit",
+    month: "2-digit",
+    day: "2-digit",
+  });
+
+  const parts = formatter.formatToParts(now);
+  const values = Object.fromEntries(
+    parts
+      .filter((part) => part.type !== "literal")
+      .map((part) => [part.type, part.value]),
+  ) as Record<"month" | "day" | "year", string>;
+
+  return `${values.month}${values.day}${values.year}`;
+}
+
+function getRandomSuffix(): string {
+  const bytes = randomBytes(RANDOM_SUFFIX_LENGTH);
+  let output = "";
+
+  for (const byte of bytes) {
+    output += REFERENCE_ID_LETTERS[byte % REFERENCE_ID_LETTERS.length];
+  }
+
+  return output;
+}
+
+export function generateReferenceId(now = new Date()): string {
+  return `${getDatePrefix(now)}-${getRandomSuffix()}`;
+}
+
+export function buildFormsparkPayload(
+  payload: ContactFormPayload,
+  referenceId: string,
+  subjectLabel: string,
+) {
+  return {
+    ...payload,
+    referenceId,
+    _email: {
+      subject: `${subjectLabel} [${referenceId}]`,
+    },
+  };
+}

--- a/apps/web-lfd/src/app/api/contact-submit/route.ts
+++ b/apps/web-lfd/src/app/api/contact-submit/route.ts
@@ -1,0 +1,82 @@
+import {
+  buildFormsparkPayload,
+  CONTACT_SUBMISSION_VALIDATION_MESSAGES,
+  generateReferenceId,
+  normalizeContactFormPayload,
+} from "@/lib/contact-submission";
+
+export const runtime = "nodejs";
+
+const FORMSPARK_URL =
+  process.env.FORMSPARK_URL ?? process.env.NEXT_PUBLIC_FORMSPARK_URL;
+const SUBJECT_LABEL = "La Famiglia DelGrosso Contact Submission";
+const GENERIC_ERROR_MESSAGE =
+  "Sorry, there was an error sending your message. Please try again.";
+
+export async function POST(request: Request): Promise<Response> {
+  if (!FORMSPARK_URL) {
+    return Response.json(
+      {
+        ok: false,
+        message: "Form service is not configured.",
+      },
+      { status: 500 },
+    );
+  }
+
+  try {
+    const body = await request.json();
+    const payload = normalizeContactFormPayload(body);
+    const referenceId = generateReferenceId();
+
+    const formsparkResponse = await fetch(FORMSPARK_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(
+        buildFormsparkPayload(payload, referenceId, SUBJECT_LABEL),
+      ),
+      cache: "no-store",
+    });
+
+    if (!formsparkResponse.ok) {
+      console.error("Formspark submission failed", {
+        status: formsparkResponse.status,
+        statusText: formsparkResponse.statusText,
+      });
+
+      return Response.json(
+        {
+          ok: false,
+          message: GENERIC_ERROR_MESSAGE,
+        },
+        { status: 502 },
+      );
+    }
+
+    return Response.json({
+      ok: true,
+      referenceId,
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : GENERIC_ERROR_MESSAGE;
+    const status = CONTACT_SUBMISSION_VALIDATION_MESSAGES.has(message)
+      ? 400
+      : 500;
+
+    if (status === 500) {
+      console.error("Contact submission route failed", error);
+    }
+
+    return Response.json(
+      {
+        ok: false,
+        message: status === 400 ? message : GENERIC_ERROR_MESSAGE,
+      },
+      { status },
+    );
+  }
+}

--- a/apps/web-lfd/src/components/page-sections/contact-page/contact-form.tsx
+++ b/apps/web-lfd/src/components/page-sections/contact-page/contact-form.tsx
@@ -14,22 +14,19 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 
 import { announce } from "@/lib/a11y/announce";
-
-const FORMSPARK_URL = process.env.NEXT_PUBLIC_FORMSPARK_URL;
+import type {
+  ContactFormPayload,
+  ContactSubmissionResponse,
+} from "@/lib/contact-submission";
 
 type FormState = "idle" | "submitting" | "success" | "error";
-
-interface ContactFormData {
-  firstName: string;
-  lastName: string;
-  email: string;
-  phone?: string;
-  brand: "la-famiglia" | "delgrosso-foods" | "organic" | "";
-  message: string;
-}
+const CONTACT_SUBMIT_ENDPOINT = "/api/contact-submit";
+const GENERIC_ERROR_MESSAGE =
+  "Sorry, there was an error sending your message. Please try again.";
 
 export function ContactForm() {
   const [formState, setFormState] = useState<FormState>("idle");
+  const [referenceId, setReferenceId] = useState<string | null>(null);
 
   const {
     register,
@@ -39,7 +36,7 @@ export function ContactForm() {
     reset,
     setValue,
     watch,
-  } = useForm<ContactFormData>({
+  } = useForm<ContactFormPayload>({
     mode: "onChange",
     defaultValues: {
       firstName: "",
@@ -53,15 +50,12 @@ export function ContactForm() {
 
   const watchedBrand = watch("brand");
 
-  const onSubmit = async (data: ContactFormData) => {
+  const onSubmit = async (data: ContactFormPayload) => {
     setFormState("submitting");
-
-    if (!FORMSPARK_URL) {
-      throw new Error("Form service not configured");
-    }
+    setReferenceId(null);
 
     try {
-      const response = await fetch(FORMSPARK_URL, {
+      const response = await fetch(CONTACT_SUBMIT_ENDPOINT, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -70,11 +64,14 @@ export function ContactForm() {
         body: JSON.stringify(data),
       });
 
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
+      const result = (await response.json()) as ContactSubmissionResponse;
+
+      if (!response.ok || !result.ok) {
+        throw new Error(result.ok ? GENERIC_ERROR_MESSAGE : result.message);
       }
 
       setFormState("success");
+      setReferenceId(result.referenceId);
       reset();
       announce(
         "Thank you for your message! We'll get back to you soon.",
@@ -84,8 +81,7 @@ export function ContactForm() {
       console.error("Form submission error:", error);
       setFormState("error");
       setError("root", {
-        message:
-          "Sorry, there was an error sending your message. Please try again.",
+        message: error instanceof Error ? error.message : GENERIC_ERROR_MESSAGE,
       });
       announce(
         "Sorry, there was an error sending your message. Please try again.",
@@ -372,6 +368,7 @@ export function ContactForm() {
               <p className="text-green-800 text-sm">
                 Thank you for your message! We&apos;ll get back to you within
                 24-48 hours.
+                {referenceId ? ` Reference ID: ${referenceId}.` : ""}
               </p>
             </div>
           </div>

--- a/apps/web-lfd/src/lib/contact-submission.ts
+++ b/apps/web-lfd/src/lib/contact-submission.ts
@@ -1,0 +1,135 @@
+import { randomBytes } from "node:crypto";
+
+const REFERENCE_ID_LETTERS = "ABCDEFGHJKMNPQRSTUVWXYZ";
+const RANDOM_SUFFIX_LENGTH = 4;
+const EASTERN_TIMEZONE = "America/New_York";
+
+export type ContactFormPayload = {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone?: string;
+  brand: "la-famiglia" | "delgrosso-foods" | "organic" | "";
+  message: string;
+};
+
+export type ContactSubmissionResponse =
+  | { ok: true; referenceId: string }
+  | { ok: false; message: string };
+
+export const CONTACT_SUBMISSION_VALIDATION_MESSAGES = new Set([
+  "Invalid form submission",
+  "First name is required",
+  "Last name is required",
+  "Email is required",
+  "Please enter a valid email address including a domain",
+  "Please select a brand",
+  "Message is required",
+  "Message must be at least 10 characters",
+]);
+
+function cleanOptional(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function requireNonEmptyString(value: unknown, fieldName: string): string {
+  const cleaned = cleanOptional(value);
+  if (!cleaned) {
+    throw new Error(`${fieldName} is required`);
+  }
+  return cleaned;
+}
+
+function normalizeEmail(value: unknown): string {
+  const email = requireNonEmptyString(value, "Email");
+  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/i;
+
+  if (!emailPattern.test(email)) {
+    throw new Error("Please enter a valid email address including a domain");
+  }
+
+  return email.toLowerCase();
+}
+
+function normalizeBrand(value: unknown): ContactFormPayload["brand"] {
+  if (
+    value === "la-famiglia" ||
+    value === "delgrosso-foods" ||
+    value === "organic"
+  ) {
+    return value;
+  }
+
+  throw new Error("Please select a brand");
+}
+
+export function normalizeContactFormPayload(
+  input: unknown,
+): ContactFormPayload {
+  if (!input || typeof input !== "object") {
+    throw new Error("Invalid form submission");
+  }
+
+  const data = input as Record<string, unknown>;
+  const message = requireNonEmptyString(data.message, "Message");
+
+  if (message.length < 10) {
+    throw new Error("Message must be at least 10 characters");
+  }
+
+  return {
+    firstName: requireNonEmptyString(data.firstName, "First name"),
+    lastName: requireNonEmptyString(data.lastName, "Last name"),
+    email: normalizeEmail(data.email),
+    phone: cleanOptional(data.phone),
+    brand: normalizeBrand(data.brand),
+    message,
+  };
+}
+
+function getDatePrefix(now: Date): string {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: EASTERN_TIMEZONE,
+    year: "2-digit",
+    month: "2-digit",
+    day: "2-digit",
+  });
+
+  const parts = formatter.formatToParts(now);
+  const values = Object.fromEntries(
+    parts
+      .filter((part) => part.type !== "literal")
+      .map((part) => [part.type, part.value]),
+  ) as Record<"month" | "day" | "year", string>;
+
+  return `${values.month}${values.day}${values.year}`;
+}
+
+function getRandomSuffix(): string {
+  const bytes = randomBytes(RANDOM_SUFFIX_LENGTH);
+  let output = "";
+
+  for (const byte of bytes) {
+    output += REFERENCE_ID_LETTERS[byte % REFERENCE_ID_LETTERS.length];
+  }
+
+  return output;
+}
+
+export function generateReferenceId(now = new Date()): string {
+  return `${getDatePrefix(now)}-${getRandomSuffix()}`;
+}
+
+export function buildFormsparkPayload(
+  payload: ContactFormPayload,
+  referenceId: string,
+  subjectLabel: string,
+) {
+  return {
+    ...payload,
+    referenceId,
+    _email: {
+      subject: `${subjectLabel} [${referenceId}]`,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add server-side `/api/contact-submit` handlers for both DGF and LFD contact forms
- generate human-friendly reference IDs in `MMDDYY-ABCD` format using US Eastern time and letter-only suffixes
- forward `referenceId` and custom `_email.subject` values to Formspark
- update both contact form UIs to submit through the internal route and show the returned reference ID on success

## Testing
- `pnpm --filter web-dgf typecheck`
- `pnpm --filter web-lfd typecheck`