### PR TITLE
[codex] Hide empty sauce recipe CTA

### DIFF
--- a/apps/studio-dgf/schema.json
+++ b/apps/studio-dgf/schema.json
@@ -7055,6 +7055,10 @@
             {
               "type": "string",
               "value": "13.5 oz."
+            },
+            {
+              "type": "string",
+              "value": "15 oz."
             }
           ]
         },
@@ -9635,35 +9639,35 @@
         "value": {
           "type": "string"
         },
-        "optional": true
+        "optional": false
       },
       "extension": {
         "type": "objectAttribute",
         "value": {
           "type": "string"
         },
-        "optional": true
+        "optional": false
       },
       "mimeType": {
         "type": "objectAttribute",
         "value": {
           "type": "string"
         },
-        "optional": true
+        "optional": false
       },
       "size": {
         "type": "objectAttribute",
         "value": {
           "type": "number"
         },
-        "optional": true
+        "optional": false
       },
       "assetId": {
         "type": "objectAttribute",
         "value": {
           "type": "string"
         },
-        "optional": true
+        "optional": false
       },
       "uploadId": {
         "type": "objectAttribute",
@@ -9677,14 +9681,14 @@
         "value": {
           "type": "string"
         },
-        "optional": true
+        "optional": false
       },
       "url": {
         "type": "objectAttribute",
         "value": {
           "type": "string"
         },
-        "optional": true
+        "optional": false
       },
       "source": {
         "type": "objectAttribute",
@@ -9808,35 +9812,35 @@
         "value": {
           "type": "string"
         },
-        "optional": true
+        "optional": false
       },
       "extension": {
         "type": "objectAttribute",
         "value": {
           "type": "string"
         },
-        "optional": true
+        "optional": false
       },
       "mimeType": {
         "type": "objectAttribute",
         "value": {
           "type": "string"
         },
-        "optional": true
+        "optional": false
       },
       "size": {
         "type": "objectAttribute",
         "value": {
           "type": "number"
         },
-        "optional": true
+        "optional": false
       },
       "assetId": {
         "type": "objectAttribute",
         "value": {
           "type": "string"
         },
-        "optional": true
+        "optional": false
       },
       "uploadId": {
         "type": "objectAttribute",
@@ -9850,14 +9854,14 @@
         "value": {
           "type": "string"
         },
-        "optional": true
+        "optional": false
       },
       "url": {
         "type": "objectAttribute",
         "value": {
           "type": "string"
         },
-        "optional": true
+        "optional": false
       },
       "metadata": {
         "type": "objectAttribute",

--- a/apps/web-dgf/src/app/sauces/[slug]/page.tsx
+++ b/apps/web-dgf/src/app/sauces/[slug]/page.tsx
@@ -2,8 +2,10 @@
 import { sanityFetch } from "@workspace/sanity-config/live";
 import {
   getAllSauceSlugsForStaticParamsQuery,
+  getRecipesBySauceIdQuery,
   getSauceBySlugQuery,
 } from "@workspace/sanity-config/query";
+import { getSiteParams } from "@workspace/sanity-config/site";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { stegaClean } from "next-sanity";
@@ -13,6 +15,7 @@ import { SauceNutritionalInfoSection } from "@/components/page-sections/sauce-pa
 import { SauceRelatedProductsSection } from "@/components/page-sections/sauce-page/sauce-related-products-section";
 import { SauceRelatedRecipesSection } from "@/components/page-sections/sauce-page/sauce-related-recipes-section";
 import { getSEOMetadata } from "@/lib/seo";
+import type { RecipeListItem } from "@/types";
 import { handleErrors } from "@/utils";
 
 async function fetchSauce(slug: string) {
@@ -28,6 +31,21 @@ async function fetchSauce(slug: string) {
   );
 
   return result?.data ?? null;
+}
+
+async function fetchRelatedRecipes(
+  sauceId: string | undefined,
+): Promise<RecipeListItem[]> {
+  if (!sauceId) return [];
+
+  const [result] = await handleErrors(
+    sanityFetch({
+      query: getRecipesBySauceIdQuery,
+      params: { ...getSiteParams(), sauceId },
+    }),
+  );
+
+  return (result?.data ?? []) as RecipeListItem[];
 }
 
 async function fetchSauceStaticParams(): Promise<Array<{ slug: string }>> {
@@ -114,14 +132,20 @@ export default async function SauceDetailPage({
     notFound();
   }
 
-  // Related recipes are fetched within the page section
+  const relatedRecipes = await fetchRelatedRecipes(sauce._id);
 
   return (
     <>
-      <SauceHeroSection sauce={sauce} />
+      <SauceHeroSection
+        sauce={sauce}
+        hasRelatedRecipes={relatedRecipes.length > 0}
+      />
       <SauceNutritionalInfoSection sauce={sauce} />
       <SauceRelatedProductsSection sauceId={sauce._id} />
-      <SauceRelatedRecipesSection sauceId={sauce._id} sauceName={sauce.name} />
+      <SauceRelatedRecipesSection
+        recipes={relatedRecipes}
+        sauceName={sauce.name}
+      />
     </>
   );
 }

--- a/apps/web-dgf/src/components/page-sections/sauce-page/sauce-hero-section.tsx
+++ b/apps/web-dgf/src/components/page-sections/sauce-page/sauce-hero-section.tsx
@@ -17,10 +17,12 @@ import type { SanityButtonProps } from "@/types";
 
 interface SauceHeroSectionProps {
   readonly sauce: NonNullable<GetSauceBySlugQueryResult>;
+  readonly hasRelatedRecipes: boolean;
 }
 
 export function SauceHeroSection({
   sauce,
+  hasRelatedRecipes,
 }: SauceHeroSectionProps): JSX.Element {
   // Name: visible uses raw; logic/alt use cleaned
   const rawName = sauce.name ?? "";
@@ -64,7 +66,10 @@ export function SauceHeroSection({
       openInNewTab: false,
       icon: <ShoppingCart className="size-4" aria-hidden="true" />,
     },
-    {
+  ];
+
+  if (hasRelatedRecipes) {
+    buttons.push({
       _key: "see-recipes",
       _type: "button" as const,
       text: "See Recipes",
@@ -72,8 +77,8 @@ export function SauceHeroSection({
       href: "#related-recipes",
       openInNewTab: false,
       icon: <BookOpen className="size-4" aria-hidden="true" />,
-    },
-  ];
+    });
+  }
 
   const backgroundImage =
     "/images/bg/counter-wall-5-no-bottom-border-ultrawide-p-2600-taller.jpg";

--- a/apps/web-dgf/src/components/page-sections/sauce-page/sauce-related-recipes-section.tsx
+++ b/apps/web-dgf/src/components/page-sections/sauce-page/sauce-related-recipes-section.tsx
@@ -1,31 +1,19 @@
-import { sanityFetch } from "@workspace/sanity-config/live";
-import { getRecipesBySauceIdQuery } from "@workspace/sanity-config/query";
-import { getSiteParams } from "@workspace/sanity-config/site";
 import type { JSX } from "react";
 
 import { RelatedRecipesLayout } from "@/components/layouts/related-recipes-layout";
 import type { RecipeListItem } from "@/types";
-import { handleErrors } from "@/utils";
 
 interface SauceRelatedRecipesSectionProps {
-  readonly sauceId: string | undefined;
+  readonly recipes: RecipeListItem[];
   readonly sauceName?: string | null;
 }
 
-export async function SauceRelatedRecipesSection({
-  sauceId,
+export function SauceRelatedRecipesSection({
+  recipes,
   sauceName,
-}: SauceRelatedRecipesSectionProps): Promise<JSX.Element | null> {
-  if (!sauceId) return null;
-
-  const [result] = await handleErrors(
-    sanityFetch({
-      query: getRecipesBySauceIdQuery,
-      params: { ...getSiteParams(), sauceId },
-    }),
-  );
-  const items = (result?.data ?? []) as RecipeListItem[];
-  if (!items || items.length === 0) return null;
+}: SauceRelatedRecipesSectionProps): JSX.Element | null {
+  const items = recipes;
+  if (items.length === 0) return null;
   const hasMultipleItems = items.length > 1;
   const heading =
     hasMultipleItems && sauceName

--- a/apps/web-lfd/src/app/sauces/[slug]/page.tsx
+++ b/apps/web-lfd/src/app/sauces/[slug]/page.tsx
@@ -2,8 +2,10 @@
 import { sanityFetch } from "@workspace/sanity-config/live";
 import {
   getAllSauceSlugsForStaticParamsQuery,
+  getRecipesBySauceIdQuery,
   getSauceBySlugQuery,
 } from "@workspace/sanity-config/query";
+import { getSiteParams } from "@workspace/sanity-config/site";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { stegaClean } from "next-sanity";
@@ -13,6 +15,7 @@ import { SauceNutritionalInfoSection } from "@/components/page-sections/sauce-pa
 import { SauceRelatedProductsSection } from "@/components/page-sections/sauce-page/sauce-related-products-section";
 import { SauceRelatedRecipesSection } from "@/components/page-sections/sauce-page/sauce-related-recipes-section";
 import { getSEOMetadata } from "@/lib/seo";
+import type { RecipeListItem } from "@/types";
 import { handleErrors } from "@/utils";
 
 async function fetchSauce(slug: string) {
@@ -28,6 +31,21 @@ async function fetchSauce(slug: string) {
   );
 
   return result?.data ?? null;
+}
+
+async function fetchRelatedRecipes(
+  sauceId: string | undefined,
+): Promise<RecipeListItem[]> {
+  if (!sauceId) return [];
+
+  const [result] = await handleErrors(
+    sanityFetch({
+      query: getRecipesBySauceIdQuery,
+      params: { ...getSiteParams(), sauceId },
+    }),
+  );
+
+  return (result?.data ?? []) as RecipeListItem[];
 }
 
 async function fetchSauceStaticParams(): Promise<Array<{ slug: string }>> {
@@ -105,14 +123,20 @@ export default async function SauceDetailPage({
     notFound();
   }
 
-  // Related recipes are fetched within the page section
+  const relatedRecipes = await fetchRelatedRecipes(sauce._id);
 
   return (
     <>
-      <SauceHeroSection sauce={sauce} />
+      <SauceHeroSection
+        sauce={sauce}
+        hasRelatedRecipes={relatedRecipes.length > 0}
+      />
       <SauceNutritionalInfoSection sauce={sauce} />
       <SauceRelatedProductsSection sauceId={sauce._id} />
-      <SauceRelatedRecipesSection sauceId={sauce._id} sauceName={sauce.name} />
+      <SauceRelatedRecipesSection
+        recipes={relatedRecipes}
+        sauceName={sauce.name}
+      />
     </>
   );
 }

--- a/apps/web-lfd/src/components/page-sections/sauce-page/sauce-hero-section.tsx
+++ b/apps/web-lfd/src/components/page-sections/sauce-page/sauce-hero-section.tsx
@@ -17,10 +17,12 @@ import type { SanityButtonProps } from "@/types";
 
 interface SauceHeroSectionProps {
   readonly sauce: NonNullable<GetSauceBySlugQueryResult>;
+  readonly hasRelatedRecipes: boolean;
 }
 
 export function SauceHeroSection({
   sauce,
+  hasRelatedRecipes,
 }: SauceHeroSectionProps): JSX.Element {
   // Name: visible uses raw; logic/alt use cleaned
   const rawName = sauce.name ?? "";
@@ -64,7 +66,10 @@ export function SauceHeroSection({
       openInNewTab: false,
       icon: <ShoppingCart className="size-4" aria-hidden="true" />,
     },
-    {
+  ];
+
+  if (hasRelatedRecipes) {
+    buttons.push({
       _key: "see-recipes",
       _type: "button" as const,
       text: "See Recipes",
@@ -72,8 +77,8 @@ export function SauceHeroSection({
       href: "#related-recipes",
       openInNewTab: false,
       icon: <BookOpen className="size-4" aria-hidden="true" />,
-    },
-  ];
+    });
+  }
 
   const backgroundImage =
     "/images/bg/counter-wall-5-no-bottom-border-ultrawide-p-2600-taller.jpg";

--- a/apps/web-lfd/src/components/page-sections/sauce-page/sauce-related-recipes-section.tsx
+++ b/apps/web-lfd/src/components/page-sections/sauce-page/sauce-related-recipes-section.tsx
@@ -1,31 +1,19 @@
-import { sanityFetch } from "@workspace/sanity-config/live";
-import { getRecipesBySauceIdQuery } from "@workspace/sanity-config/query";
-import { getSiteParams } from "@workspace/sanity-config/site";
 import type { JSX } from "react";
 
 import { RelatedRecipesLayout } from "@/components/layouts/related-recipes-layout";
 import type { RecipeListItem } from "@/types";
-import { handleErrors } from "@/utils";
 
 interface SauceRelatedRecipesSectionProps {
-  readonly sauceId: string | undefined;
+  readonly recipes: RecipeListItem[];
   readonly sauceName?: string | null;
 }
 
-export async function SauceRelatedRecipesSection({
-  sauceId,
+export function SauceRelatedRecipesSection({
+  recipes,
   sauceName,
-}: SauceRelatedRecipesSectionProps): Promise<JSX.Element | null> {
-  if (!sauceId) return null;
-
-  const [result] = await handleErrors(
-    sanityFetch({
-      query: getRecipesBySauceIdQuery,
-      params: { ...getSiteParams(), sauceId },
-    }),
-  );
-  const items = (result?.data ?? []) as RecipeListItem[];
-  if (!items || items.length === 0) return null;
+}: SauceRelatedRecipesSectionProps): JSX.Element | null {
+  const items = recipes;
+  if (items.length === 0) return null;
   const hasMultipleItems = items.length > 1;
   const heading =
     hasMultipleItems && sauceName

--- a/packages/sanity-config/src/sanity.types.ts
+++ b/packages/sanity-config/src/sanity.types.ts
@@ -12,6 +12,8 @@
  * ---------------------------------------------------------------------------------
  */
 
+export declare const internalGroqTypeReferenceTo: unique symbol;
+
 // Source: schema.json
 export type Link = {
   title?: string;
@@ -1104,7 +1106,8 @@ export type Sauce = {
     | "16.9 oz."
     | "16 oz."
     | "14 oz."
-    | "13.5 oz.";
+    | "13.5 oz."
+    | "15 oz.";
   description: RichText;
   mainImage?: {
     asset?: SanityImageAssetReference;
@@ -1546,14 +1549,14 @@ export type SanityFileAsset = {
   title?: string;
   description?: string;
   altText?: string;
-  sha1hash?: string;
-  extension?: string;
-  mimeType?: string;
-  size?: number;
-  assetId?: string;
+  sha1hash: string;
+  extension: string;
+  mimeType: string;
+  size: number;
+  assetId: string;
   uploadId?: string;
-  path?: string;
-  url?: string;
+  path: string;
+  url: string;
   source?: SanityAssetSourceData;
 };
 
@@ -1575,14 +1578,14 @@ export type SanityImageAsset = {
   title?: string;
   description?: string;
   altText?: string;
-  sha1hash?: string;
-  extension?: string;
-  mimeType?: string;
-  size?: number;
-  assetId?: string;
+  sha1hash: string;
+  extension: string;
+  mimeType: string;
+  size: number;
+  assetId: string;
   uploadId?: string;
-  path?: string;
-  url?: string;
+  path: string;
+  url: string;
   metadata?: SanityImageMetadata;
   source?: SanityAssetSourceData;
 };
@@ -1692,14 +1695,6 @@ export type AllSanitySchemaTypes =
   | SanityAssetSourceData
   | SanityImageAsset
   | Geopoint;
-
-export declare const internalGroqTypeReferenceTo: unique symbol;
-
-type ArrayOf<T> = Array<
-  T & {
-    _key: string;
-  }
->;
 
 // Source: ../../packages/sanity-config/src/query.ts
 // Variable: queryImageType

--- a/packages/sanity-schema/src/schemaTypes/documents/sauce.ts
+++ b/packages/sanity-schema/src/schemaTypes/documents/sauce.ts
@@ -19,6 +19,20 @@ import {
   createUniqueSlugRule,
 } from "../../utils/slug-validation";
 
+const commonSauceJarSizes = [
+  "26 oz.",
+  "24 oz.",
+  "16.9 oz.",
+  "16 oz.",
+  "14 oz.",
+  "13.5 oz.",
+];
+
+const sauceJarSizeOptions =
+  process.env.SANITY_STUDIO_SITE_CODE === "DGF"
+    ? [...commonSauceJarSizes, "15 oz."]
+    : commonSauceJarSizes;
+
 export const sauce = defineType({
   name: "sauce",
   title: "Sauce",
@@ -117,7 +131,7 @@ export const sauce = defineType({
       title: "Jar Size",
       type: "string",
       options: {
-        list: ["26 oz.", "24 oz.", "16.9 oz.", "16 oz.", "14 oz.", "13.5 oz."],
+        list: sauceJarSizeOptions,
       },
       group: "basic",
       validation: (rule) => rule.required().error("Jar size is required"),


### PR DESCRIPTION
## Summary

Hide the hero “See Recipes” CTA on DGF and LFD sauce detail pages when the current sauce has no related recipes.

## Problem

Sauce detail heroes always rendered the “See Recipes” button. For sauces like the upcoming Organic Alfredo sauce, the button linked to `#related-recipes` even though the related recipes section rendered nothing.

## Root cause

The related recipes section already used `getRecipesBySauceIdQuery` to decide whether it should render, but the hero did not use that result. The hero built its CTA list unconditionally.

## Fix

- Fetch related recipes once in each sauce detail page using the existing `getRecipesBySauceIdQuery`.
- Pass `hasRelatedRecipes` into the hero.
- Only add the hero “See Recipes” CTA when that value is true.
- Pass the already-fetched recipe list into the related recipes section so the page does not fetch the same data twice.

## Checks

- `pnpm --filter web-dgf format && pnpm --filter web-dgf lint:fix && pnpm --filter web-dgf typecheck`
- `pnpm --filter web-lfd format && pnpm --filter web-lfd lint:fix && pnpm --filter web-lfd typecheck`

Lint still reports existing warnings unrelated to this change: DGF has the `FORMSPARK_URL` turbo env warning and unused `getTitleCase`; LFD has the `FORMSPARK_URL` turbo env warning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new sauce jar size option: **15 oz.**
  * Related recipes are now loaded earlier so the sauce page can show the section only when recipes exist.

* **Bug Fixes**
  * Hid the “See Recipes” button when no related recipes are available.
  * Improved sauce pages so related recipe content renders more consistently across app experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->