### PR TITLE
[codex] fix store pack source copy

### DIFF
--- a/apps/web-dgf/src/app/store/[slug]/page.tsx
+++ b/apps/web-dgf/src/app/store/[slug]/page.tsx
@@ -251,11 +251,10 @@ export default async function ProductDetailPage({
             ) : hasManySauces ? (
               <>
                 <div className="text-center">
-                  <Eyebrow text="Pairs well with" />
-                  <h2 className="heading-section">Complementary sauces</h2>
+                  <Eyebrow text="Sauce Info" />
+                  <h2 className="heading-section">Sauces in this Pack</h2>
                   <p className="mt-4 text-muted-foreground">
-                    Build your next meal with these favorites from La Famiglia
-                    DelGrosso.
+                    Click on any of the sauces below to get more info.
                   </p>
                 </div>
 

--- a/apps/web-lfd/src/app/store/[slug]/page.tsx
+++ b/apps/web-lfd/src/app/store/[slug]/page.tsx
@@ -242,11 +242,10 @@ export default async function ProductDetailPage({
             ) : hasManySauces ? (
               <>
                 <div className="text-center">
-                  <Eyebrow text="Pairs well with" />
-                  <h2 className="heading-section">Complementary sauces</h2>
+                  <Eyebrow text="Sauce Info" />
+                  <h2 className="heading-section">Sauces in this Pack</h2>
                   <p className="mt-4 text-muted-foreground">
-                    Build your next meal with these favorites from La Famiglia
-                    DelGrosso.
+                    Click on any of the sauces below to get more info.
                   </p>
                 </div>
 


### PR DESCRIPTION
## Issue

On DGF and LFD product detail pages, gift packs with more than one sauce showed copy that framed the sauces as related or complementary recommendations.

## Cause and user effect

The multi-sauce branch on `/store/{slug}` reused related-sauce language: "Pairs well with", "Complementary sauces", and meal-building helper copy. For gift packs, those sauce cards are not recommendations; they are the sauces included in the pack. That made the section misleading for shoppers.

## Fix

Updated the multi-sauce source section copy in both web apps:

- Eyebrow: `Sauce Info`
- Heading: `Sauces in this Pack`
- Body: `Click on any of the sauces below to get more info.`

Touched files:

- `apps/web-dgf/src/app/store/[slug]/page.tsx`
- `apps/web-lfd/src/app/store/[slug]/page.tsx`

## Validation

Checked the Italian Classics Gift Pack route locally on both apps:

- `http://127.0.0.1:3000/store/italian-classics-gift-pack`
- `http://127.0.0.1:3001/store/italian-classics-gift-pack`

Confirmed the new copy renders and the old related-sauce copy no longer appears in either store page source.

Ran:

- `pnpm --filter web-dgf format`
- `pnpm --filter web-lfd format`
- `pnpm --filter web-dgf lint:fix`
- `pnpm --filter web-lfd lint:fix`
- `pnpm --filter web-dgf typecheck`
- `pnpm --filter web-lfd typecheck`

Lint completed with existing unrelated warnings only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the wording in the sauces section on product detail pages.
  * Replaced “Complementary sauces” copy with clearer “Sauces in this Pack” / “Sauce Info” labels.
  * Added guidance encouraging shoppers to click sauces for more details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->