### PR TITLE
[codex] Fix ultra-premium product line filter slug

### DIFF
--- a/apps/web-dgf/src/components/elements/product-card.tsx
+++ b/apps/web-dgf/src/components/elements/product-card.tsx
@@ -109,7 +109,10 @@ export function ProductCard({
     // Unique line badge (skip if mixed/none)
     const lineSlug = getUniqueLineSlug(sauceLines ?? undefined);
     if (lineSlug) {
-      badges.push({ text: lineMap[lineSlug].display, variant: lineSlug });
+      badges.push({
+        text: lineMap[lineSlug].display,
+        variant: lineMap[lineSlug].badgeVariant,
+      });
     }
 
     // Type badge: single => specific, multiple => Mix

--- a/apps/web-dgf/src/components/features/catalog/products-client.tsx
+++ b/apps/web-dgf/src/components/features/catalog/products-client.tsx
@@ -289,7 +289,7 @@ export function ProductsClient({ items, initialState }: Props) {
         ...filters.productLine.map((slug) => ({
           key: `line-${slug}`,
           text: lineMap[slug].display,
-          variant: slug,
+          variant: lineMap[slug].badgeVariant,
           onRemove: () => toggleLine(slug, false),
         })),
         ...(filters.sauceType !== "all" && filters.sauceType !== "mix"

--- a/apps/web-dgf/src/components/features/catalog/recipes-client.tsx
+++ b/apps/web-dgf/src/components/features/catalog/recipes-client.tsx
@@ -358,7 +358,7 @@ export function RecipesClient({ items, initialState, categories }: Props) {
         ...filters.productLine.map((slug) => ({
           key: `line-${slug}`,
           text: lineMap[slug].display,
-          variant: slug,
+          variant: lineMap[slug].badgeVariant,
           onRemove: () => toggleLine(slug, false),
         })),
         ...filters.tags.map((slug) => ({

--- a/apps/web-dgf/src/components/page-sections/sauce-page/sauce-hero-section.tsx
+++ b/apps/web-dgf/src/components/page-sections/sauce-page/sauce-hero-section.tsx
@@ -52,7 +52,7 @@ export function SauceHeroSection({
       ? "DelGrosso's Original"
       : lineSlug === "organic"
         ? "DelGrosso Organic"
-        : lineSlug === "premium"
+        : lineSlug === "ultra-premium"
           ? "La Famiglia DelGrosso's"
           : getLineDisplayName(rawLine);
 
@@ -107,7 +107,7 @@ export function SauceHeroSection({
   const authorAltText = authorImage?.alt || cleanedAuthorName || "Sauce author";
 
   const showAuthor =
-    lineSlug === "premium" && (hasAuthorName || authorImage?.id);
+    lineSlug === "ultra-premium" && (hasAuthorName || authorImage?.id);
 
   const authorNameAttribute = showAuthor
     ? createPresentationDataAttribute({

--- a/apps/web-dgf/src/config/sauce-taxonomy.ts
+++ b/apps/web-dgf/src/config/sauce-taxonomy.ts
@@ -2,8 +2,9 @@
 // Mapping canonical slugs to Sanity labels, display labels, and badge colors
 import { stegaClean } from "next-sanity";
 
-export type LineSlug = "original" | "organic" | "premium";
+export type LineSlug = "original" | "organic" | "ultra-premium";
 export type TypeSlug = "pasta" | "pizza" | "salsa" | "sandwich";
+export type LineBadgeVariant = "original" | "organic" | "premium";
 
 export type LineLabel = "Original" | "Organic" | "Ultra-Premium";
 export type TypeLabel =
@@ -16,15 +17,16 @@ export interface BadgeConfig {
   readonly text: string;
   /**
    * Visual variant key expected by the shared <Badge /> component.
-   * Typically the canonical slug (e.g., "original", "organic", "pizza").
+   * Product lines may use a separate visual key (e.g., ultra-premium -> premium).
    */
-  readonly variant: "neutral" | LineSlug | TypeSlug;
+  readonly variant: "neutral" | LineBadgeVariant | TypeSlug;
 }
 
 interface LineConfigItem {
   readonly label: LineLabel;
   readonly display: string;
   readonly displayName?: string;
+  readonly badgeVariant: LineBadgeVariant;
 }
 
 interface TypeConfigItem {
@@ -43,15 +45,18 @@ export const lineMap: Record<LineSlug, LineConfigItem> = {
   original: {
     label: "Original",
     display: "Original",
+    badgeVariant: "original",
   },
   organic: {
     label: "Organic",
     display: "Organic",
+    badgeVariant: "organic",
   },
-  premium: {
+  "ultra-premium": {
     label: "Ultra-Premium",
     display: "Ultra Premium",
     displayName: "La Famiglia DelGrosso",
+    badgeVariant: "premium",
   },
 } as const;
 
@@ -87,7 +92,7 @@ export const typeMap: Record<TypeSlug, TypeConfigItem> = {
 const inverseLine: Record<LineLabel, LineSlug> = {
   Original: "original",
   Organic: "organic",
-  "Ultra-Premium": "premium",
+  "Ultra-Premium": "ultra-premium",
 } as const;
 
 /**
@@ -103,8 +108,8 @@ const inverseType: Record<TypeLabel, TypeSlug> = {
 /**
  * Convert a human-readable product line label from Sanity into a canonical line slug.
  *
- * Why: UI components (e.g., Badge variants, filters) key off stable slugs
- * such as "original"/"organic"/"premium" rather than the display labels.
+ * Why: filters key off URL-safe slugs such as "original"/"organic"/"ultra-premium"
+ * rather than display labels.
  *
  * Note: Strings coming from the Sanity Live Content API may contain hidden
  * steganographic metadata for live preview features. We call `stegaClean` to
@@ -113,7 +118,7 @@ const inverseType: Record<TypeLabel, TypeSlug> = {
  * Examples:
  * - toLineSlug("Original") -> "original"
  * - toLineSlug("Organic") -> "organic"
- * - toLineSlug("Ultra-Premium") -> "premium"
+ * - toLineSlug("Ultra-Premium") -> "ultra-premium"
  */
 export function toLineSlug(label: unknown): LineSlug | undefined {
   if (!label) return undefined;
@@ -121,6 +126,25 @@ export function toLineSlug(label: unknown): LineSlug | undefined {
   // Clean it to ensure exact key matches against our inverse map.
   const clean = stegaClean(String(label));
   return inverseLine[clean as LineLabel];
+}
+
+const legacyLineSlugParamAliases: Partial<Record<string, LineSlug>> = {
+  premium: "ultra-premium",
+} as const;
+
+/**
+ * Convert incoming URL param values into canonical product line slugs.
+ *
+ * Serializers only emit canonical slugs. The legacy "premium" param is accepted
+ * so old links are normalized to "ultra-premium" on page load.
+ */
+export function toLineSlugFromParam(value: unknown): LineSlug | undefined {
+  if (!value) return undefined;
+  const clean = stegaClean(String(value));
+  if ((allLineSlugs as readonly string[]).includes(clean)) {
+    return clean as LineSlug;
+  }
+  return legacyLineSlugParamAliases[clean];
 }
 
 /**
@@ -189,7 +213,7 @@ export function getLineBadge(label: unknown): BadgeConfig {
   }
   return {
     text: cfg.display,
-    variant: slug ?? "neutral",
+    variant: cfg.badgeVariant,
   };
 }
 
@@ -240,7 +264,11 @@ export function getTypeBadge(label: unknown): BadgeConfig {
  * Enumerates all valid product line slugs.
  * Useful for filters, checkboxes, or generating UI menus.
  */
-export const allLineSlugs: LineSlug[] = ["original", "organic", "premium"];
+export const allLineSlugs: LineSlug[] = [
+  "original",
+  "organic",
+  "ultra-premium",
+];
 
 /**
  * Enumerates all valid sauce type slugs.

--- a/apps/web-dgf/src/lib/product-line-url.test.ts
+++ b/apps/web-dgf/src/lib/product-line-url.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { allLineSlugs, toLineSlug } from "../config/sauce-taxonomy";
+import {
+  parseSearchParams as parseProductSearchParams,
+  serializeStateToParams as serializeProductStateToParams,
+} from "./products/url";
+import {
+  parseSearchParams as parseSauceSearchParams,
+  serializeStateToParams as serializeSauceStateToParams,
+} from "./sauces/url";
+
+test("uses ultra-premium as the canonical product line slug", () => {
+  assert.equal(toLineSlug("Ultra-Premium"), "ultra-premium");
+  assert.deepEqual(allLineSlugs, ["original", "organic", "ultra-premium"]);
+});
+
+test("serializes sauce product line filters with ultra-premium", () => {
+  const params = serializeSauceStateToParams({
+    search: "",
+    productLine: ["ultra-premium"],
+    sauceType: "all",
+    sort: "az",
+  });
+
+  assert.equal(params.toString(), "productLine=ultra-premium");
+});
+
+test("serializes store product line filters with ultra-premium", () => {
+  const params = serializeProductStateToParams({
+    search: "",
+    packaging: [],
+    productLine: ["ultra-premium"],
+    sauceType: "all",
+    sort: "az",
+  });
+
+  assert.equal(params.toString(), "productLine=ultra-premium");
+});
+
+test("normalizes old premium query params to ultra-premium", () => {
+  assert.deepEqual(
+    parseSauceSearchParams({ productLine: "premium" }).productLine,
+    ["ultra-premium"],
+  );
+  assert.deepEqual(
+    parseProductSearchParams({ productLine: "premium" }).productLine,
+    ["ultra-premium"],
+  );
+});

--- a/apps/web-dgf/src/lib/products/url.ts
+++ b/apps/web-dgf/src/lib/products/url.ts
@@ -1,8 +1,8 @@
 import type { PackagingSlug } from "@/config/product-taxonomy";
 import {
-  allLineSlugs,
   allTypeSlugs,
   type LineSlug,
+  toLineSlugFromParam,
   type TypeSlug,
 } from "@/config/sauce-taxonomy";
 import type { SortOrder } from "@/types";
@@ -41,9 +41,9 @@ export function parseSearchParams(
   );
 
   const productLineRaw = toArray(params.productLine);
-  const productLine = productLineRaw.filter((v): v is LineSlug =>
-    (allLineSlugs as readonly string[]).includes(v),
-  ) as LineSlug[];
+  const productLine = productLineRaw
+    .map(toLineSlugFromParam)
+    .filter((v): v is LineSlug => v !== undefined);
 
   const sauceTypeRaw =
     typeof params.sauceType === "string" ? params.sauceType : undefined;

--- a/apps/web-dgf/src/lib/recipes/url.ts
+++ b/apps/web-dgf/src/lib/recipes/url.ts
@@ -4,7 +4,7 @@ import {
   type MeatSlug,
   type RecipeTagSlug,
 } from "@/config/recipe-taxonomy";
-import { allLineSlugs, type LineSlug } from "@/config/sauce-taxonomy";
+import { type LineSlug, toLineSlugFromParam } from "@/config/sauce-taxonomy";
 import type { SortOrder } from "@/types";
 
 // Utility function to generate slug from title
@@ -60,9 +60,9 @@ export function parseSearchParams(
   const search = typeof params.search === "string" ? params.search : "";
 
   const productLineRaw = toArray(params.productLine);
-  const productLine = productLineRaw.filter((v): v is LineSlug =>
-    (allLineSlugs as readonly string[]).includes(v),
-  ) as LineSlug[];
+  const productLine = productLineRaw
+    .map(toLineSlugFromParam)
+    .filter((v): v is LineSlug => v !== undefined);
 
   const tagsRaw = toArray(params.tags);
   const tags = tagsRaw.filter((v): v is RecipeTagSlug =>

--- a/apps/web-dgf/src/lib/redirects/legacy-product-redirects.ts
+++ b/apps/web-dgf/src/lib/redirects/legacy-product-redirects.ts
@@ -127,23 +127,23 @@ export const legacyProductRedirectSpec: readonly RedirectSpec[] = [
   },
   {
     source: "/products/ultra-premium/",
-    destination: "/sauces?productLine=premium",
+    destination: "/sauces?productLine=ultra-premium",
   },
   {
     source: "/products/ultra-premium/red-pasta-sauce/",
-    destination: "/sauces?productLine=premium&sauceType=pasta",
+    destination: "/sauces?productLine=ultra-premium&sauceType=pasta",
   },
   {
     source: "/products/ultra-premium/white-pasta-sauce/",
-    destination: "/sauces?productLine=premium&sauceType=pasta",
+    destination: "/sauces?productLine=ultra-premium&sauceType=pasta",
   },
   {
     source: "/products/ultra-premium/pizza-sauce/",
-    destination: "/sauces?productLine=premium&sauceType=pizza",
+    destination: "/sauces?productLine=ultra-premium&sauceType=pizza",
   },
   {
     source: "/products/ultra-premium/sandwich-sauce/",
-    destination: "/sauces?productLine=premium&sauceType=sandwich",
+    destination: "/sauces?productLine=ultra-premium&sauceType=sandwich",
   },
 ] as const;
 

--- a/apps/web-dgf/src/lib/sauces/url.ts
+++ b/apps/web-dgf/src/lib/sauces/url.ts
@@ -1,7 +1,7 @@
 import {
-  allLineSlugs,
   allTypeSlugs,
   type LineSlug,
+  toLineSlugFromParam,
   type TypeSlug,
 } from "@/config/sauce-taxonomy";
 import type { SortOrder } from "@/types";
@@ -33,9 +33,9 @@ export function parseSearchParams(
   const search = typeof params.search === "string" ? params.search : "";
 
   const productLineRaw = toArray(params.productLine);
-  const productLine = productLineRaw.filter((v): v is LineSlug =>
-    (allLineSlugs as readonly string[]).includes(v),
-  ) as LineSlug[];
+  const productLine = productLineRaw
+    .map(toLineSlugFromParam)
+    .filter((v): v is LineSlug => v !== undefined);
 
   const sauceTypeRaw =
     typeof params.sauceType === "string" ? params.sauceType : undefined;


### PR DESCRIPTION
## Summary

This fixes the DGF `/sauces` and `/store` product line filter URL for the Ultra Premium sauce line.

The issue was that the UI label said "Ultra Premium", but the canonical filter slug was still `premium`. When a user selected the filter, the app generated URLs like `/sauces?productLine=premium`. The client wants the URL nomenclature to match the line name, so the generated URL now uses `/sauces?productLine=ultra-premium`.

Root cause: `LineSlug` and `lineMap` treated the LFD / Ultra-Premium line as `premium`, and the URL serializers wrote that internal slug directly to `productLine` search params.

Fix:

- Changed the canonical product line slug from `premium` to `ultra-premium`.
- Kept the existing badge visual variant as `premium`, so styling does not change.
- Updated `/sauces`, `/store`, and recipes URL parsing to accept `ultra-premium`.
- Kept `productLine=premium` as a legacy accepted param and normalize it to `ultra-premium`.
- Updated legacy Ultra Premium product redirects to emit `productLine=ultra-premium`.
- Added regression coverage for sauce and store URL serialization.

## Verification

- `pnpm exec tsx --test src/lib/product-line-url.test.ts` from `apps/web-dgf`
- `pnpm --filter web-dgf format`
- `pnpm --filter web-dgf lint:fix` passed with 2 existing warnings:
  - `FORMSPARK_URL is not listed as a dependency in turbo.json`
  - `getTitleCase is defined but never used`
- `pnpm --filter web-dgf typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product lines now display and filter using **Ultra-Premium** instead of the previous label.
  * Older links with the legacy product line value still open the correct results.

* **Bug Fixes**
  * Fixed badge and chip styling so selected product lines use the correct visual variant.
  * Updated sauce hero labels and author display for Ultra-Premium content.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->